### PR TITLE
Background image fix

### DIFF
--- a/themes/docsy/assets/scss/blocks/_cover.scss
+++ b/themes/docsy/assets/scss/blocks/_cover.scss
@@ -3,17 +3,16 @@
 @include td-box-height-modifiers(".td-cover-block");
 
 .td-cover-logo {
-    margin-right: 0.5em;
+  margin-right: 0.5em;
 }
 
 .td-cover-block {
-    position: relative;
-    padding-top: 5rem;
-    padding-bottom: 5rem;
-    background: {
-        repeat: no-repeat;
-        position: 50% 0;
-        size: cover;
-    };
-
+  position: relative;
+  padding-top: 5rem;
+  padding-bottom: 5rem;
+  background: {
+    repeat: no-repeat;
+    position: right; /* modified */
+    size: contain; /* modified */
+  }
 }

--- a/themes/docsy/assets/scss/blocks/_cover.scss
+++ b/themes/docsy/assets/scss/blocks/_cover.scss
@@ -3,16 +3,16 @@
 @include td-box-height-modifiers(".td-cover-block");
 
 .td-cover-logo {
-  margin-right: 0.5em;
+    margin-right: 0.5em;
 }
 
 .td-cover-block {
-  position: relative;
-  padding-top: 5rem;
-  padding-bottom: 5rem;
-  background: {
-    repeat: no-repeat;
-    position: right; /* modified */
-    size: contain; /* modified */
-  }
+    position: relative;
+    padding-top: 5rem;
+    padding-bottom: 5rem;
+    background: {
+        repeat: no-repeat;
+        position: right; /* modified */
+        size: contain; /* modified */
+    }
 }

--- a/themes/docsy/assets/scss/blocks/_cover.scss
+++ b/themes/docsy/assets/scss/blocks/_cover.scss
@@ -14,5 +14,5 @@
         repeat: no-repeat;
         position: right; /* modified */
         size: contain; /* modified */
-    }
+    };
 }


### PR DESCRIPTION
Currently, the image will scale based on viewport size. The image size (which we probably don't want to increase much due to filesize) doesn't suit itself well for large screen and ends up super pixellated. Working on a reasonable SVG solution for a more permanent fix soon.