### PR TITLE
fix: tweak "edit this page" links

### DIFF
--- a/themes/docsy/layouts/partials/page-meta-links.html
+++ b/themes/docsy/layouts/partials/page-meta-links.html
@@ -7,8 +7,10 @@
 {{ $editURL := printf "%s/edit/master/content/%s" $gh_repo .Path }}
 {{ if and ($gh_subdir) (.Site.Language.Lang) }}
 {{ $editURL = printf "%s/edit/master/%s/content/%s/%s" $gh_repo $gh_subdir ($.Site.Language.Lang) $.Path }}
+{{/*
 {{ else if .Site.Language.Lang }}
 {{ $editURL = printf "%s/edit/master/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
+*/}}
 {{ else if $gh_subdir }}
 {{ $editURL = printf "%s/edit/master/%s/content/%s" $gh_repo $gh_subdir $.Path }}
 {{ end }}


### PR DESCRIPTION
pretty sure it's the wrong fix, but after messing with a lot of config values in multiple config files, i'm not sure what the proper fix is.

the core issue is that the site throws in a language designator `/en` in the links so i tried tweaking all the language configuration and consulted the docs to no avail. if someone knows a proper fix, feel free to close this and open their own PR.