### PR TITLE
Windows Installation, Grammatical Fixes, and Link Fixes

### DIFF
--- a/content/usage/getting-started/enable_repo.md
+++ b/content/usage/getting-started/enable_repo.md
@@ -15,12 +15,12 @@ to the repo.
 
 For this example, we'll go over using the UI to add the repo. You can always head over to the [CLI docs](/docs/usage/reference/cli/repo/add/) for docs on how to add a repo via CLI.
 
-1. Log into your Vela instance
-1. Click "Add Repositories"
-1. Select the Org from the available list
-1. Click "Add" next to the repo you would like to add
-  1. Alternatively you can "Add All" repos in an org
-  1. If you're repo doesn't exist, try clicking "Refresh List" in the top right.
+1. Log into your Vela instance.
+1. Click "Add Repositories".
+1. Select the Org from the available list.
+1. Click "Add" next to the repo you would like to add.
+  1. Alternatively you can "Add All" repos in an org.
+  1. If your repo doesn't exist, try clicking "Refresh List" in the top right.
 
 
 Your repo now has the necessary web hook to Vela.

--- a/content/usage/getting-started/roles.md
+++ b/content/usage/getting-started/roles.md
@@ -10,7 +10,7 @@ description: >
 At this time the only Source Control Provider is GitHub. So this documentation is tailored for those users.
 {{% /alert %}}
 
-Vela does not maintain any authentication (AuthN) or authorization (AuthZ) internally but instead, inherits its access from the source (version control) provider. More information on GitHub's access model can be founds their [documentation](https://help.github.com/en/articles/access-permissions-on-github).
+Vela does not maintain any authentication (AuthN) or authorization (AuthZ) internally, but instead inherits its access from the source (version control) provider. More information on GitHub's access model can be found in their [documentation](https://help.github.com/en/articles/access-permissions-on-github).
 
 Platform Roles:
 
@@ -28,11 +28,11 @@ Platform admins have full control when interacting with the CLI, UI, and API.
 
 ### Source Provider Roles:
 
-Admins within the GitHub organization have the option to use GitHub orgs to allow users to have permissions on all repositories in the org, or to use fine grained access of adding access for users directly to individual repositories.
+Admins within the GitHub organization have the option to use GitHub orgs to allow users to have permissions on all repositories in the org, or to use fine-grained access of adding access for users directly to individual repositories.
 
 #### Admin
 
-The **admin** role enables full access to the repository which grants the following access levels for resources:
+The **admin** role enables full access to the repository, which grants the following access levels for resources:
 
 | Access | Repo | Build | Step | Service | Log | Secret  |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|
@@ -41,7 +41,7 @@ The **admin** role enables full access to the repository which grants the follow
 
 #### Write
 
-The **write** role enables read and write access to the repository which grants the following access levels for resources:
+The **write** role enables read and write access to the repository, which grants the following access levels for resources:
 
 | Access | Repo | Build | Step | Service | Log | Secret  |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|
@@ -50,7 +50,7 @@ The **write** role enables read and write access to the repository which grants 
 
 #### Read
 
-The **read** role enables read access to the repository which grants the following access levels for resources:
+The **read** role enables read access to the repository, which grants the following access levels for resources:
 
 | Access | Repo | Build | Step | Service | Log | Secret  |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|

--- a/content/usage/getting-started/start_build.md
+++ b/content/usage/getting-started/start_build.md
@@ -6,6 +6,6 @@ description: >
   Start a build for the first time.
 ---
 
-If you've followed the documentation for [enabling a repo](/docs/usage/getting-started/enabling_repo/) and [writing a pipeline](/docs/usage/getting-started/write_pipeline/) all that should be left is to push your pipeline to your repo.
+If you've followed the documentation for [enabling a repo](/docs/usage/getting-started/enable_repo/) and [writing a pipeline](/docs/usage/getting-started/write_pipeline/), all that should be left is to push your pipeline to your repo.
 
 If a build does not trigger when your push a change to your repo, check the webhook response to see if there is an error.

--- a/content/usage/getting-started/write_pipeline.md
+++ b/content/usage/getting-started/write_pipeline.md
@@ -51,7 +51,7 @@ Vela automatically clones your repository into a local volume, the workspace, th
 
 ### Commands
 
-Vela allows you to specify commands that executed within the default shell inside your build container. By default commands use the root of your repository as the working directory.
+Vela allows you to specify commands that are executed within the default shell inside your build container. By default commands use the root of your repository as the working directory.
 
 ```yaml
 pipeline:

--- a/content/usage/pipeline/steps/secrets.md
+++ b/content/usage/pipeline/steps/secrets.md
@@ -71,4 +71,4 @@ steps:
 
 ### Reference Secret
 
-Vela offers a number of different ways to reference your secrets. To see the full set of options navigate to the [secret reference](/usage/reference/secrets) section.
+Vela offers a number of different ways to reference your secrets. To see the full set of options navigate to the [secret reference](/usage/reference/pipeline/secret/) section.

--- a/content/usage/reference/cli/install.md
+++ b/content/usage/reference/cli/install.md
@@ -59,7 +59,6 @@ Note: `curl` must be installed differently
 curl -L https://github.com/go-vela/cli/releases/download/v0.1.5/vela_windows_amd64.tar.gz --output vela_windows_amd64.tar.gz
 # unzipping the tarball
 tar xzvf vela_windows_amd64.tar.gz
-cp vela C:\Windows\System32/vela.exe
 # copy binary to $PATH
 copy vela C:\Windows\System32/vela.exe
 ```
@@ -82,7 +81,6 @@ cp vela C:\Windows\System32/vela.exe
 curl -L https://github.com/go-vela/cli/releases/download/v0.1.5/vela_windows_amd64.tar.gz --output vela_windows_amd64.tar.gz
 # unzipping the tarball
 tar xzvf vela_windows_amd64.tar.gz
-cp vela C:\Windows\System32/vela.exe
 # copy binary to $PATH
 cp vela C:\Windows\System32/vela.exe
 ```

--- a/content/usage/reference/cli/install.md
+++ b/content/usage/reference/cli/install.md
@@ -50,12 +50,41 @@ sudo cp vela /usr/local/bin/
 
 #### cURL
 
+Note: `curl` must be installed differently
+
+##### Command Prompt
+
 ```sh
 # download the binary
-curl -L https://github.com/go-vela/cli/releases/download/v0.1.5/vela_windows_amd64.tar.gz | tar zx
-
+curl -L https://github.com/go-vela/cli/releases/download/v0.1.5/vela_windows_amd64.tar.gz --output vela_windows_amd64.tar.gz
+# unzipping the tarball
+tar xzvf vela_windows_amd64.tar.gz
+cp vela C:\Windows\System32/vela.exe
 # copy binary to $PATH
-sudo cp vela C:\Windows\System32
+copy vela C:\Windows\System32/vela.exe
+```
+
+##### Windows PowerShell
+
+```sh
+# download the binary
+curl https://github.com/go-vela/cli/releases/download/v0.1.5/vela_windows_amd64.tar.gz -OutFile vela_windows_amd64.tar.gz
+# unzipping the tarball
+tar xzvf vela_windows_amd64.tar.gz
+# copy binary to $PATH
+cp vela C:\Windows\System32/vela.exe
+```
+
+##### PowerShell 6 (PowerShell Core)
+
+```sh
+# download the binary
+curl -L https://github.com/go-vela/cli/releases/download/v0.1.5/vela_windows_amd64.tar.gz --output vela_windows_amd64.tar.gz
+# unzipping the tarball
+tar xzvf vela_windows_amd64.tar.gz
+cp vela C:\Windows\System32/vela.exe
+# copy binary to $PATH
+cp vela C:\Windows\System32/vela.exe
 ```
 
 ### From Source


### PR DESCRIPTION
What was changed:
- Instructions for `cmd.exe (Command Prompt)`, `Windows PowerShell`, and `PowerShell 6 (PowerShell Core)`
  - note: only 2 characters change between cmd.exe and PowerShell
- Various proof-reading changes
- Fixed 2 broken link to properly redirect

More information can be found in each commit.

