### PR TITLE
docs: fix up links

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -106,6 +106,6 @@ no = 'Sorry to hear that. Please <a href="https://github.com/go-vela/docs/issues
         desc = "Chat with other project developers"
 [[params.links.developer]]
 	name = "Developer mailing list"
-	url = "vela@target.com"
+	url = "mailto:vela@target.com"
 	icon = "fa fa-envelope"
         desc = "Discuss development issues around the project"

--- a/content/api/admin/_index.md
+++ b/content/api/admin/_index.md
@@ -10,5 +10,5 @@ The below endpoints are available to operate on as an admin of the platform.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}

--- a/content/api/admin/build.md
+++ b/content/api/admin/build.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/admin/hook.md
+++ b/content/api/admin/hook.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/admin/repo.md
+++ b/content/api/admin/repo.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/admin/secret.md
+++ b/content/api/admin/secret.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request
@@ -51,12 +51,8 @@ curl \
     "name": "foo",
     "value": null,
     "type": "repo",
-    "images": [
-      "alpine"
-    ],
-    "events": [
-      "push"
-    ]
+    "images": ["alpine"],
+    "events": ["push"]
   },
   {
     "id": 2,
@@ -66,12 +62,8 @@ curl \
     "name": "bar",
     "value": null,
     "type": "repo",
-    "images": [
-      "alpine"
-    ],
-    "events": [
-      "push"
-    ]
+    "images": ["alpine"],
+    "events": ["push"]
   }
 ]
 ```

--- a/content/api/admin/service.md
+++ b/content/api/admin/service.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request
@@ -54,7 +54,7 @@ curl \
     "exit_code": 0,
     "created": 1563475419,
     "started": 1563475420,
-    "finished": 1563475421,
+    "finished": 1563475421
   },
   {
     "id": 1,
@@ -67,7 +67,7 @@ curl \
     "exit_code": 0,
     "created": 1563475419,
     "started": 1563475420,
-    "finished": 1563475421,
+    "finished": 1563475421
   }
 ]
 ```

--- a/content/api/admin/step.md
+++ b/content/api/admin/step.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/admin/user.md
+++ b/content/api/admin/user.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request
@@ -47,9 +47,7 @@ curl \
     "id": 2,
     "name": "octocat",
     "token": null,
-    "favorites": [
-      "github/octocat"
-    ],
+    "favorites": ["github/octocat"],
     "active": true,
     "admin": false
   },
@@ -57,9 +55,7 @@ curl \
     "id": 1,
     "name": "OctoKitty",
     "token": null,
-    "favorites": [
-      "github/octocat"
-    ],
+    "favorites": ["github/octocat"],
     "active": true,
     "admin": false
   }

--- a/content/api/build/_index.md
+++ b/content/api/build/_index.md
@@ -10,5 +10,5 @@ The below endpoints are available to operate on the `build` resource.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}

--- a/content/api/build/add.md
+++ b/content/api/build/add.md
@@ -36,7 +36,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File

--- a/content/api/build/get.md
+++ b/content/api/build/get.md
@@ -36,7 +36,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/build/logs.md
+++ b/content/api/build/logs.md
@@ -37,7 +37,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/build/remove.md
+++ b/content/api/build/remove.md
@@ -37,7 +37,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/build/restart.md
+++ b/content/api/build/restart.md
@@ -37,7 +37,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/build/update.md
+++ b/content/api/build/update.md
@@ -37,7 +37,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File

--- a/content/api/build/view.md
+++ b/content/api/build/view.md
@@ -37,7 +37,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/hook/_index.md
+++ b/content/api/hook/_index.md
@@ -10,5 +10,5 @@ The below endpoints are available to operate on the `hook` resource.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}

--- a/content/api/hook/add.md
+++ b/content/api/hook/add.md
@@ -36,7 +36,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File

--- a/content/api/hook/get.md
+++ b/content/api/hook/get.md
@@ -36,7 +36,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/hook/remove.md
+++ b/content/api/hook/remove.md
@@ -37,7 +37,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/hook/update.md
+++ b/content/api/hook/update.md
@@ -37,7 +37,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File

--- a/content/api/hook/view.md
+++ b/content/api/hook/view.md
@@ -37,7 +37,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/repo/_index.md
+++ b/content/api/repo/_index.md
@@ -10,5 +10,5 @@ The below endpoints are available to operate on the `repo` resource.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}

--- a/content/api/repo/add.md
+++ b/content/api/repo/add.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File
@@ -37,7 +37,7 @@ To authenticate to the API, please review the [authentication documentation](/do
   "owner": "github",
   "name": "octocat",
   "link": "https://github.com/github/octocat",
-  "clone": "https://github.com/github/octocat.git",
+  "clone": "https://github.com/github/octocat.git"
 }
 ```
 

--- a/content/api/repo/chown.md
+++ b/content/api/repo/chown.md
@@ -36,7 +36,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/repo/get.md
+++ b/content/api/repo/get.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/repo/remove.md
+++ b/content/api/repo/remove.md
@@ -15,10 +15,10 @@ DELETE  /api/v1/repos/:org/:repo
 
 The following parameters are used to configure the endpoint:
 
-| Name    | Description          |
-| ------- | -------------------- |
-| `org`   | name of organization |
-| `repo`  | name of repository   |
+| Name   | Description          |
+| ------ | -------------------- |
+| `org`  | name of organization |
+| `repo` | name of repository   |
 
 ## Permissions
 
@@ -36,7 +36,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/repo/repair.md
+++ b/content/api/repo/repair.md
@@ -15,10 +15,10 @@ PATCH  /api/v1/repos/:org/:repo/repair
 
 The following parameters are used to configure the endpoint:
 
-| Name    | Description          |
-| ------- | -------------------- |
-| `org`   | name of organization |
-| `repo`  | name of repository   |
+| Name   | Description          |
+| ------ | -------------------- |
+| `org`  | name of organization |
+| `repo` | name of repository   |
 
 ## Permissions
 
@@ -36,7 +36,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/repo/update.md
+++ b/content/api/repo/update.md
@@ -15,10 +15,10 @@ PUT  /api/v1/repos/:org/:repo
 
 The following parameters are used to configure the endpoint:
 
-| Name    | Description          |
-| ------- | -------------------- |
-| `org`   | name of organization |
-| `repo`  | name of repository   |
+| Name   | Description          |
+| ------ | -------------------- |
+| `org`  | name of organization |
+| `repo` | name of repository   |
 
 ## Permissions
 
@@ -36,7 +36,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File

--- a/content/api/repo/view.md
+++ b/content/api/repo/view.md
@@ -15,10 +15,10 @@ GET  /api/v1/repos/:org/:repo
 
 The following parameters are used to configure the endpoint:
 
-| Name    | Description          |
-| ------- | -------------------- |
-| `org`   | name of organization |
-| `repo`  | name of repository   |
+| Name   | Description          |
+| ------ | -------------------- |
+| `org`  | name of organization |
+| `repo` | name of repository   |
 
 ## Permissions
 
@@ -36,7 +36,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/secret/_index.md
+++ b/content/api/secret/_index.md
@@ -10,5 +10,5 @@ The below endpoints are available to operate on the `secret` resource.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}

--- a/content/api/secret/add.md
+++ b/content/api/secret/add.md
@@ -15,12 +15,12 @@ POST  /api/v1/secrets/:engine/:type/:org/:name
 
 The following parameters are used to configure the endpoint:
 
-| Name     | Description                  |
-| -------- | ---------------------------- |
-| `engine` | name of engine               |
-| `type`   | name of type of secret       |
-| `org`    | name of organization         |
-| `name`   | name of repository or team   |
+| Name     | Description                |
+| -------- | -------------------------- |
+| `engine` | name of engine             |
+| `type`   | name of type of secret     |
+| `org`    | name of organization       |
+| `name`   | name of repository or team |
 
 ## Permissions
 
@@ -38,7 +38,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File
@@ -74,11 +74,7 @@ curl \
   "name": "foo",
   "value": null,
   "type": "repo",
-  "images": [
-    "alpine"
-  ],
-  "events": [
-    "push"
-  ]
+  "images": ["alpine"],
+  "events": ["push"]
 }
 ```

--- a/content/api/secret/get.md
+++ b/content/api/secret/get.md
@@ -15,12 +15,12 @@ GET  /api/v1/secrets/:engine/:type/:org/:name
 
 The following parameters are used to configure the endpoint:
 
-| Name     | Description                  |
-| -------- | ---------------------------- |
-| `engine` | name of engine               |
-| `type`   | name of type of secret       |
-| `org`    | name of organization         |
-| `name`   | name of repository or team   |
+| Name     | Description                |
+| -------- | -------------------------- |
+| `engine` | name of engine             |
+| `type`   | name of type of secret     |
+| `org`    | name of organization       |
+| `name`   | name of repository or team |
 
 ## Permissions
 
@@ -38,7 +38,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request
@@ -62,12 +62,8 @@ curl \
     "name": "foo",
     "value": null,
     "type": "repo",
-    "images": [
-      "alpine"
-    ],
-    "events": [
-      "push"
-    ]
+    "images": ["alpine"],
+    "events": ["push"]
   },
   {
     "id": 2,
@@ -77,12 +73,8 @@ curl \
     "name": "bar",
     "value": null,
     "type": "repo",
-    "images": [
-      "alpine"
-    ],
-    "events": [
-      "push"
-    ]
+    "images": ["alpine"],
+    "events": ["push"]
   }
 ]
 ```

--- a/content/api/secret/remove.md
+++ b/content/api/secret/remove.md
@@ -15,13 +15,13 @@ DELETE  /api/v1/secrets/:engine/:type/:org/:name/:secret
 
 The following parameters are used to configure the endpoint:
 
-| Name     | Description                  |
-| -------- | ---------------------------- |
-| `engine` | name of engine               |
-| `type`   | name of type of secret       |
-| `org`    | name of organization         |
-| `name`   | name of repository or team   |
-| `secret` | name of secret               |
+| Name     | Description                |
+| -------- | -------------------------- |
+| `engine` | name of engine             |
+| `type`   | name of type of secret     |
+| `org`    | name of organization       |
+| `name`   | name of repository or team |
+| `secret` | name of secret             |
 
 ## Permissions
 
@@ -39,7 +39,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/secret/update.md
+++ b/content/api/secret/update.md
@@ -15,13 +15,13 @@ PUT  /api/v1/secrets/:engine/:type/:org/:name/:secret
 
 The following parameters are used to configure the endpoint:
 
-| Name     | Description                  |
-| -------- | ---------------------------- |
-| `engine` | name of engine               |
-| `type`   | name of type of secret       |
-| `org`    | name of organization         |
-| `name`   | name of repository or team   |
-| `secret` | name of secret               |
+| Name     | Description                |
+| -------- | -------------------------- |
+| `engine` | name of engine             |
+| `type`   | name of type of secret     |
+| `org`    | name of organization       |
+| `name`   | name of repository or team |
+| `secret` | name of secret             |
 
 ## Permissions
 
@@ -39,7 +39,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File
@@ -72,12 +72,7 @@ curl \
   "name": "foo",
   "value": "",
   "type": "repo",
-  "images": [
-    "alpine"
-  ],
-  "events": [
-    "push",
-    "tag"
-  ]
+  "images": ["alpine"],
+  "events": ["push", "tag"]
 }
 ```

--- a/content/api/secret/view.md
+++ b/content/api/secret/view.md
@@ -15,13 +15,13 @@ GET  /api/v1/secrets/:engine/:type/:org/:name/:secret
 
 The following parameters are used to configure the endpoint:
 
-| Name     | Description                  |
-| -------- | ---------------------------- |
-| `engine` | name of engine               |
-| `type`   | name of type of secret       |
-| `org`    | name of organization         |
-| `name`   | name of repository or team   |
-| `secret` | name of secret               |
+| Name     | Description                |
+| -------- | -------------------------- |
+| `engine` | name of engine             |
+| `type`   | name of type of secret     |
+| `org`    | name of organization       |
+| `name`   | name of repository or team |
+| `secret` | name of secret             |
 
 ## Permissions
 
@@ -39,7 +39,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request
@@ -62,11 +62,7 @@ curl \
   "name": "foo",
   "value": "",
   "type": "repo",
-  "images": [
-    "alpine"
-  ],
-  "events": [
-    "push"
-  ]
+  "images": ["alpine"],
+  "events": ["push"]
 }
 ```

--- a/content/api/service/_index.md
+++ b/content/api/service/_index.md
@@ -10,5 +10,5 @@ The below endpoints are available to operate on the `service` resource.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}

--- a/content/api/service/add.md
+++ b/content/api/service/add.md
@@ -37,7 +37,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File
@@ -74,6 +74,6 @@ curl \
   "exit_code": 0,
   "created": 1563475419,
   "started": 1563475420,
-  "finished": 1563475421,
+  "finished": 1563475421
 }
 ```

--- a/content/api/service/get.md
+++ b/content/api/service/get.md
@@ -37,7 +37,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request
@@ -64,7 +64,7 @@ curl \
     "exit_code": 0,
     "created": 1563475419,
     "started": 1563475420,
-    "finished": 1563475421,
+    "finished": 1563475421
   },
   {
     "id": 1,
@@ -77,7 +77,7 @@ curl \
     "exit_code": 0,
     "created": 1563475419,
     "started": 1563475420,
-    "finished": 1563475421,
+    "finished": 1563475421
   }
 ]
 ```

--- a/content/api/service/logs.md
+++ b/content/api/service/logs.md
@@ -38,7 +38,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/service/remove.md
+++ b/content/api/service/remove.md
@@ -38,7 +38,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/service/update.md
+++ b/content/api/service/update.md
@@ -38,7 +38,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File
@@ -74,6 +74,6 @@ curl \
   "exit_code": 0,
   "created": 1563475419,
   "started": 1563475420,
-  "finished": 1563475421,
+  "finished": 1563475421
 }
 ```

--- a/content/api/service/view.md
+++ b/content/api/service/view.md
@@ -38,7 +38,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request
@@ -64,6 +64,6 @@ curl \
   "exit_code": 0,
   "created": 1563475419,
   "started": 1563475420,
-  "finished": 1563475421,
+  "finished": 1563475421
 }
 ```

--- a/content/api/step/_index.md
+++ b/content/api/step/_index.md
@@ -10,5 +10,5 @@ The below endpoints are available to operate on the `step` resource.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}

--- a/content/api/step/add.md
+++ b/content/api/step/add.md
@@ -37,7 +37,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File

--- a/content/api/step/get.md
+++ b/content/api/step/get.md
@@ -37,7 +37,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/step/logs.md
+++ b/content/api/step/logs.md
@@ -38,7 +38,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/step/remove.md
+++ b/content/api/step/remove.md
@@ -38,7 +38,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/step/update.md
+++ b/content/api/step/update.md
@@ -38,7 +38,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File

--- a/content/api/step/view.md
+++ b/content/api/step/view.md
@@ -38,7 +38,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/user/_index.md
+++ b/content/api/user/_index.md
@@ -10,5 +10,5 @@ The below endpoints are available to operate on the `user` resource.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}

--- a/content/api/user/add.md
+++ b/content/api/user/add.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File
@@ -35,9 +35,7 @@ To authenticate to the API, please review the [authentication documentation](/do
 ```json
 {
   "name": "OctoKitty",
-  "favorites": [
-    "github/octocat"
-  ],
+  "favorites": ["github/octocat"],
   "active": true,
   "admin": false
 }
@@ -61,9 +59,7 @@ curl \
   "id": 1,
   "name": "OctoKitty",
   "token": null,
-  "favorites": [
-    "github/octocat"
-  ],
+  "favorites": ["github/octocat"],
   "active": true,
   "admin": false
 }

--- a/content/api/user/current/_index.md
+++ b/content/api/user/current/_index.md
@@ -10,5 +10,5 @@ The below endpoints are available to operate on for the current user.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}

--- a/content/api/user/current/repos.md
+++ b/content/api/user/current/repos.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/user/current/update.md
+++ b/content/api/user/current/update.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File
@@ -56,9 +56,7 @@ curl \
   "id": 1,
   "name": "OctoKitty",
   "token": null,
-  "favorites": [
-    "github/octocat"
-  ],
+  "favorites": ["github/octocat"],
   "active": true,
   "admin": true
 }

--- a/content/api/user/current/view.md
+++ b/content/api/user/current/view.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request
@@ -46,9 +46,7 @@ curl \
   "id": 1,
   "name": "OctoKitty",
   "token": null,
-  "favorites": [
-    "github/octocat"
-  ],
+  "favorites": ["github/octocat"],
   "active": true,
   "admin": false
 }

--- a/content/api/user/get.md
+++ b/content/api/user/get.md
@@ -27,7 +27,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request
@@ -47,9 +47,7 @@ curl \
     "id": 2,
     "name": "octocat",
     "token": null,
-    "favorites": [
-      "github/octocat"
-    ],
+    "favorites": ["github/octocat"],
     "active": true,
     "admin": false
   },
@@ -57,9 +55,7 @@ curl \
     "id": 1,
     "name": "OctoKitty",
     "token": null,
-    "favorites": [
-      "github/octocat"
-    ],
+    "favorites": ["github/octocat"],
     "active": true,
     "admin": false
   }

--- a/content/api/user/remove.md
+++ b/content/api/user/remove.md
@@ -35,7 +35,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/api/user/update.md
+++ b/content/api/user/update.md
@@ -35,7 +35,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### File
@@ -64,9 +64,7 @@ curl \
   "id": 1,
   "name": "OctoKitty",
   "token": null,
-  "favorites": [
-    "github/octocat"
-  ],
+  "favorites": ["github/octocat"],
   "active": true,
   "admin": true
 }

--- a/content/api/user/view.md
+++ b/content/api/user/view.md
@@ -35,7 +35,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}
 
 #### Request
@@ -54,9 +54,7 @@ curl \
   "id": 1,
   "name": "OctoKitty",
   "token": null,
-  "favorites": [
-    "github/octocat"
-  ],
+  "favorites": ["github/octocat"],
   "active": true,
   "admin": false
 }

--- a/content/cli/authentication.md
+++ b/content/cli/authentication.md
@@ -46,7 +46,7 @@ vela generate config --addr https://vela-server.localhost --token qwerty123
 ```
 
 {{% alert color="info" %}}
-For more information, you can visit the [CLI config documentation](/docs/cli/config).
+For more information, you can visit the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ### Environment Variables

--- a/content/cli/build/_index.md
+++ b/content/cli/build/_index.md
@@ -10,7 +10,7 @@ The below commands are available to operate on the `build` resource.
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/build/get.md
+++ b/content/cli/build/get.md
@@ -28,10 +28,10 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -43,7 +43,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/build/restart.md
+++ b/content/cli/build/restart.md
@@ -19,19 +19,19 @@ For more information, you can run `vela restart build --help`.
 
 The following parameters are used to configure the command:
 
-| Name     | Description          | Environment    |
-| -------- | -------------------- | -------------- |
-| `org`    | name of organization | `BUILD_ORG`    |
-| `repo`   | name of repository   | `BUILD_REPO`   |
-| `build`  | number of build      | `BUILD_NUMBER` |
+| Name    | Description          | Environment    |
+| ------- | -------------------- | -------------- |
+| `org`   | name of organization | `BUILD_ORG`    |
+| `repo`  | name of repository   | `BUILD_REPO`   |
+| `build` | number of build      | `BUILD_NUMBER` |
 
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -43,7 +43,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/build/view.md
+++ b/content/cli/build/view.md
@@ -29,10 +29,10 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -44,7 +44,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/config/_index.md
+++ b/content/cli/config/_index.md
@@ -10,7 +10,7 @@ The below commands are available to operate on the `config` resource.
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/config/generate.md
+++ b/content/cli/config/generate.md
@@ -39,7 +39,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/config/remove.md
+++ b/content/cli/config/remove.md
@@ -39,7 +39,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/config/update.md
+++ b/content/cli/config/update.md
@@ -39,7 +39,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/config/view.md
+++ b/content/cli/config/view.md
@@ -24,7 +24,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/log/_index.md
+++ b/content/cli/log/_index.md
@@ -10,7 +10,7 @@ The below commands are available to operate on the `log` resource.
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/log/view.md
+++ b/content/cli/log/view.md
@@ -19,19 +19,19 @@ For more information, you can run `vela view log --help`.
 
 The following parameters are used to configure the command:
 
-| Name     | Description          | Environment    |
-| -------- | -------------------- | -------------- |
-| `org`    | name of organization | `BUILD_ORG`    |
-| `repo`   | name of repository   | `BUILD_REPO`   |
-| `build`  | number of build      | `BUILD_NUMBER` |
+| Name    | Description          | Environment    |
+| ------- | -------------------- | -------------- |
+| `org`   | name of organization | `BUILD_ORG`    |
+| `repo`  | name of repository   | `BUILD_REPO`   |
+| `build` | number of build      | `BUILD_NUMBER` |
 
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -43,7 +43,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/pipeline/_index.md
+++ b/content/cli/pipeline/_index.md
@@ -10,7 +10,7 @@ The below commands are available to operate on the `pipeline` resource.
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/pipeline/generate.md
+++ b/content/cli/pipeline/generate.md
@@ -34,7 +34,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/repo/_index.md
+++ b/content/cli/repo/_index.md
@@ -10,7 +10,7 @@ The below commands are available to operate on the `repo` resource.
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/repo/add.md
+++ b/content/cli/repo/add.md
@@ -34,10 +34,10 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -49,7 +49,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/repo/chown.md
+++ b/content/cli/repo/chown.md
@@ -28,10 +28,10 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -43,7 +43,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/repo/get.md
+++ b/content/cli/repo/get.md
@@ -32,7 +32,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/repo/remove.md
+++ b/content/cli/repo/remove.md
@@ -28,10 +28,10 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -43,7 +43,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/repo/repair.md
+++ b/content/cli/repo/repair.md
@@ -28,10 +28,10 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -43,7 +43,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/repo/update.md
+++ b/content/cli/repo/update.md
@@ -34,10 +34,10 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -49,7 +49,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/repo/view.md
+++ b/content/cli/repo/view.md
@@ -28,10 +28,10 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -43,7 +43,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/secret/_index.md
+++ b/content/cli/secret/_index.md
@@ -10,7 +10,7 @@ The below commands are available to operate on the `secret` resource.
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/secret/add.md
+++ b/content/cli/secret/add.md
@@ -35,12 +35,12 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `engine`
-* `type`
-* `org`
-* `repo`
+- `engine`
+- `type`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -52,7 +52,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/secret/get.md
+++ b/content/cli/secret/get.md
@@ -31,12 +31,12 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `engine`
-* `type`
-* `org`
-* `repo`
+- `engine`
+- `type`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -48,7 +48,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/secret/remove.md
+++ b/content/cli/secret/remove.md
@@ -31,12 +31,12 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `engine`
-* `type`
-* `org`
-* `repo`
+- `engine`
+- `type`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -48,7 +48,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/secret/update.md
+++ b/content/cli/secret/update.md
@@ -35,12 +35,12 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `engine`
-* `type`
-* `org`
-* `repo`
+- `engine`
+- `type`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -52,7 +52,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/secret/view.md
+++ b/content/cli/secret/view.md
@@ -32,12 +32,12 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `engine`
-* `type`
-* `org`
-* `repo`
+- `engine`
+- `type`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -49,7 +49,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/service/_index.md
+++ b/content/cli/service/_index.md
@@ -10,7 +10,7 @@ The below commands are available to operate on the `service` resource.
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/service/get.md
+++ b/content/cli/service/get.md
@@ -29,10 +29,10 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -44,7 +44,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/service/view.md
+++ b/content/cli/service/view.md
@@ -30,10 +30,10 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -45,7 +45,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/step/_index.md
+++ b/content/cli/step/_index.md
@@ -10,7 +10,7 @@ The below commands are available to operate on the `step` resource.
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/step/get.md
+++ b/content/cli/step/get.md
@@ -29,10 +29,10 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -44,7 +44,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/step/view.md
+++ b/content/cli/step/view.md
@@ -30,10 +30,10 @@ The following parameters are used to configure the command:
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
 
-* `org`
-* `repo`
+- `org`
+- `repo`
 
-For more information, please review the [CLI config documentation](/docs/cli/config).
+For more information, please review the [CLI config documentation](/docs/cli/config/).
 {{% /alert %}}
 
 ## Permissions
@@ -45,7 +45,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}

--- a/content/cli/validate.md
+++ b/content/cli/validate.md
@@ -25,7 +25,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you have already installed and setup the CLI.
 
-To install the CLI, please review the [installation documentation](/docs/cli/install).
+To install the CLI, please review the [installation documentation](/docs/cli/install/).
 To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
 {{% /alert %}}
 

--- a/content/concepts/infrastructure/server/compiler.md
+++ b/content/concepts/infrastructure/server/compiler.md
@@ -7,4 +7,4 @@ description: >
 
 The `compiler` component is one of the server components for Vela.
 
-This component defines the system Vela uses for transforming a [pipeline](/docs/concepts/pipeline) into an executable representation for the [worker](/docs/concepts/infrastructure/worker).
+This component defines the system Vela uses for transforming a [pipeline](/docs/concepts/pipeline/) into an executable representation for the [worker](/docs/concepts/infrastructure/worker).

--- a/content/concepts/pipeline/_index.md
+++ b/content/concepts/pipeline/_index.md
@@ -8,7 +8,7 @@ description: >
 The `pipeline` component is a list of repeatable, execution instructions for Vela.
 
 {{% alert color="info" %}}
-A single, ephemeral run of a pipeline is known as a [build](/docs/concepts/resources/build).
+A single, ephemeral run of a pipeline is known as a [build](/docs/concepts/resources/build/).
 {{% /alert %}}
 
 It can be thought of as a defined workflow for how you test, build, and deploy your code.

--- a/content/concepts/pipeline/metadata.md
+++ b/content/concepts/pipeline/metadata.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the metadata component for a pipeline.
 ---
 
-The `metadata` component is a part of a [pipeline](/docs/concepts/pipeline) for Vela.
+The `metadata` component is a part of a [pipeline](/docs/concepts/pipeline/) for Vela.
 
 This declaration allows extra information to be passed to the pipeline.
 

--- a/content/concepts/pipeline/secrets/_index.md
+++ b/content/concepts/pipeline/secrets/_index.md
@@ -5,12 +5,12 @@ description: >
   This section contains information on the secrets component for a pipeline.
 ---
 
-The `secrets` component is a part of a [pipeline](/docs/concepts/pipeline) for Vela.
+The `secrets` component is a part of a [pipeline](/docs/concepts/pipeline/) for Vela.
 
 This declaration allows you to provide sensitive information into the pipeline.
 
 {{% alert color="info" %}}
-A single, ephemeral run of a pipeline is known as a [build](/docs/concepts/system/build).
+A single, ephemeral run of a pipeline is known as a [build](/docs/concepts/system/build/).
 {{% /alert %}}
 
 Secrets are always retrieved at the beginning of a pipeline before any services, stages or steps are created or started. They are extremely useful when you don't want to provide sensitive information in plain text.
@@ -32,10 +32,11 @@ The following fields are used to configure the component:
 
 {{% alert color="info" %}}
 The following fields have a default value already set:
-* `engine`: `native`
-* `key`: `<secret name>`
-* `type`: `repo`
-{{% /alert %}}
+
+- `engine`: `native`
+- `key`: `<secret name>`
+- `type`: `repo`
+  {{% /alert %}}
 
 ## Syntax
 
@@ -70,10 +71,12 @@ steps:
 
 {{% alert color="info" %}}
 This pipeline will allow the following secrets to be referenced:
-* `username`
-* `password`
+
+- `username`
+- `password`
 
 This pipeline will also add the following environment variables to the `test` step:
-* `USERNAME=<value>`
-* `PASSWORD=<value>`
-{{% /alert %}}
+
+- `USERNAME=<value>`
+- `PASSWORD=<value>`
+  {{% /alert %}}

--- a/content/concepts/pipeline/services/_index.md
+++ b/content/concepts/pipeline/services/_index.md
@@ -5,12 +5,12 @@ description: >
   This section contains information on the services component for a pipeline.
 ---
 
-The `services` component is a part of a [pipeline](/docs/concepts/pipeline) for Vela.
+The `services` component is a part of a [pipeline](/docs/concepts/pipeline/) for Vela.
 
 This declaration allows you to provide detached (headless), execution instructions for a pipeline.
 
 {{% alert color="info" %}}
-A single, ephemeral run of a pipeline is known as a [build](/docs/concepts/system/build).
+A single, ephemeral run of a pipeline is known as a [build](/docs/concepts/system/build/).
 {{% /alert %}}
 
 Services are always executed, in parallel inside an ephemeral [Docker container](https://www.docker.com/resources/what-container). They are extremely useful when your testing requires additional services such as a cache, database or queue.
@@ -23,14 +23,14 @@ Services are always created at the beginning of a pipeline.
 
 The following fields are used to configure the component:
 
-| Name          | Description                                                 | Required |
-| ------------- | ----------------------------------------------------------- | -------- |
-| `entrypoint`  | command to execute inside the container                     | `false`  |
-| `environment` | variables injected into the container environment           | `false`  |
-| `image`       | Docker image used to create ephemeral container             | `true`   |
-| `name`        | unique identifier for the container in the pipeline         | `true`   |
-| `ports`       | list of ports to map for the container in the pipeline      | `false`  |
-| `pull`        | enable pulling the latest version of the image              | `false`  |
+| Name          | Description                                            | Required |
+| ------------- | ------------------------------------------------------ | -------- |
+| `entrypoint`  | command to execute inside the container                | `false`  |
+| `environment` | variables injected into the container environment      | `false`  |
+| `image`       | Docker image used to create ephemeral container        | `true`   |
+| `name`        | unique identifier for the container in the pipeline    | `true`   |
+| `ports`       | list of ports to map for the container in the pipeline | `false`  |
+| `pull`        | enable pulling the latest version of the image         | `false`  |
 
 ## Syntax
 

--- a/content/concepts/pipeline/stages/_index.md
+++ b/content/concepts/pipeline/stages/_index.md
@@ -5,12 +5,12 @@ description: >
   This section contains information on the stages component for a pipeline.
 ---
 
-The `stages` component is a part of a [pipeline](/docs/concepts/pipeline) for Vela.
+The `stages` component is a part of a [pipeline](/docs/concepts/pipeline/) for Vela.
 
 This declaration allows you to provide parallel, execution instructions for a pipeline.
 
 {{% alert color="info" %}}
-A single, ephemeral run of a pipeline is known as a [build](/docs/concepts/system/build).
+A single, ephemeral run of a pipeline is known as a [build](/docs/concepts/system/build/).
 {{% /alert %}}
 
 Stages are always executed, in parallel, and are comprised of one or many [steps](/docs/concepts/pipeline/steps).

--- a/content/concepts/pipeline/steps/_index.md
+++ b/content/concepts/pipeline/steps/_index.md
@@ -5,12 +5,12 @@ description: >
   This section contains information on the steps component for a pipeline.
 ---
 
-The `steps` component is a part of a [pipeline](/docs/concepts/pipeline) for Vela.
+The `steps` component is a part of a [pipeline](/docs/concepts/pipeline/) for Vela.
 
 This declaration allows you to provide sequential, execution instructions for a pipeline.
 
 {{% alert color="info" %}}
-A single, ephemeral run of a pipeline is known as a [build](/docs/concepts/system/build).
+A single, ephemeral run of a pipeline is known as a [build](/docs/concepts/system/build/).
 {{% /alert %}}
 
 Steps are always executed, in the order they are defined, inside an ephemeral [Docker container](https://www.docker.com/resources/what-container).

--- a/content/concepts/pipeline/version.md
+++ b/content/concepts/pipeline/version.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the version component for a pipeline.
 ---
 
-The `version` component is a part of a [pipeline](/docs/concepts/pipeline) for Vela.
+The `version` component is a part of a [pipeline](/docs/concepts/pipeline/) for Vela.
 
 This declaration allows you to provide the syntax version used to evaluate the pipeline.
 

--- a/content/concepts/system/build.md
+++ b/content/concepts/system/build.md
@@ -7,7 +7,7 @@ description: >
 
 The `build` component is part of the core system components for Vela.
 
-A `build` is defined as a single, ephemeral execution of a [pipeline](/docs/concepts/pipeline).
+A `build` is defined as a single, ephemeral execution of a [pipeline](/docs/concepts/pipeline/).
 
 A build is comprised of one or many [services](/docs/concepts/system/service) and [steps](/docs/concepts/system/step) that contain the instructions to execute from the pipeline.
 
@@ -55,7 +55,7 @@ This component is stored in the configured Vela backend in the `builds` table.
 
 ## References
 
-* [API](/docs/api/build)
-* [CLI](/docs/cli/build)
-* SDK
-  * [Go](/docs/sdk/go/build)
+- [API](/docs/api/build/)
+- [CLI](/docs/cli/build/)
+- SDK
+  - [Go](/docs/sdk/go/build/)

--- a/content/concepts/system/hook.md
+++ b/content/concepts/system/hook.md
@@ -9,7 +9,7 @@ The `hook` component is part of the core system components for Vela.
 
 A `hook` is defined as a single, webhook object received from a [repo](/docs/concepts/system/repo) in the source control provider prompting Vela to perform an action.
 
-In most cases, processing a hook involves fetching the [pipeline](/docs/concepts/pipeline) from the repo and triggering a [build](/docs/concepts/system/build).
+In most cases, processing a hook involves fetching the [pipeline](/docs/concepts/pipeline/) from the repo and triggering a [build](/docs/concepts/system/build/).
 
 {{% alert color="info" %}}
 From [GitHub's webhook documentation](https://help.github.com/en/github/extending-github/about-webhooks):
@@ -22,20 +22,20 @@ From [GitHub's webhook documentation](https://help.github.com/en/github/extendin
 
 The following fields make up this component:
 
-| Name           | Type     | Description                                               |
-| -------------- | -------- | --------------------------------------------------------- |
-| `branch`       | `string` | branch from the commit that triggered the hook            |
-| `build_id`     | `int64`  | unique identifier for build created from the hook         |
-| `created`      | `int64`  | UNIX timestamp for when the hook was created              |
-| `error`        | `string` | error message received during hook processing             |
-| `event`        | `string` | event from the commit that triggered the hook             |
-| `host`         | `string` | hostname the hook was received from                       |
-| `id`           | `int64`  | unique identifier for hook in the system                  |
-| `link`         | `string` | full navigatable url to hook from source control provider |
-| `number`       | `int`    | unique identifier for hook triggered from the repo        |
-| `repo_id`      | `int64`  | unique identifier for repo that triggered the hook        |
-| `status`       | `string` | signifies the end condition for the hook                  |
-| `source_id`    | `string` | unique identifier for hook from source control provider   |
+| Name        | Type     | Description                                               |
+| ----------- | -------- | --------------------------------------------------------- |
+| `branch`    | `string` | branch from the commit that triggered the hook            |
+| `build_id`  | `int64`  | unique identifier for build created from the hook         |
+| `created`   | `int64`  | UNIX timestamp for when the hook was created              |
+| `error`     | `string` | error message received during hook processing             |
+| `event`     | `string` | event from the commit that triggered the hook             |
+| `host`      | `string` | hostname the hook was received from                       |
+| `id`        | `int64`  | unique identifier for hook in the system                  |
+| `link`      | `string` | full navigatable url to hook from source control provider |
+| `number`    | `int`    | unique identifier for hook triggered from the repo        |
+| `repo_id`   | `int64`  | unique identifier for repo that triggered the hook        |
+| `status`    | `string` | signifies the end condition for the hook                  |
+| `source_id` | `string` | unique identifier for hook from source control provider   |
 
 {{% alert color="info" %}}
 This component is stored in the configured Vela backend in the `hooks` table.
@@ -43,7 +43,7 @@ This component is stored in the configured Vela backend in the `hooks` table.
 
 ## References
 
-* [API](/docs/api/build)
-* [CLI](/docs/cli/hook)
-* SDK
-  * [Go](/docs/sdk/go/hook)
+- [API](/docs/api/build/)
+- [CLI](/docs/cli/hook)
+- SDK
+  - [Go](/docs/sdk/go/hook)

--- a/content/concepts/system/log.md
+++ b/content/concepts/system/log.md
@@ -7,7 +7,7 @@ description: >
 
 The `log` component is part of the core system components for Vela.
 
-A `log` is defined as a sequence of records about the actions performed by a worker in a [build](/docs/concepts/system/build).
+A `log` is defined as a sequence of records about the actions performed by a worker in a [build](/docs/concepts/system/build/).
 
 ## Fields
 
@@ -28,13 +28,13 @@ This component is stored in the configured Vela backend in the `logs` table.
 
 ## References
 
-* API
-  * [Build](/docs/api/build/logs)
-  * [Service](/docs/api/service/logs)
-  * [Step](/docs/api/step/logs)
-* [CLI](/docs/cli/log)
-* SDK
-  * Go
-    * [Build](/docs/sdk/go/build/logs)
-    * [Service](/docs/sdk/go/service/logs)
-    * [Step](/docs/sdk/go/step/logs)
+- API
+  - [Build](/docs/api/build/logs)
+  - [Service](/docs/api/service/logs)
+  - [Step](/docs/api/step/logs)
+- [CLI](/docs/cli/log)
+- SDK
+  - Go
+    - [Build](/docs/sdk/go/build/logs)
+    - [Service](/docs/sdk/go/service/logs)
+    - [Step](/docs/sdk/go/step/logs)

--- a/content/concepts/system/service.md
+++ b/content/concepts/system/service.md
@@ -7,7 +7,7 @@ description: >
 
 The `service` component is part of the core system components for Vela.
 
-A `service` is defined as a detached (headless), execution instruction for a [pipeline](/docs/concepts/pipeline).
+A `service` is defined as a detached (headless), execution instruction for a [pipeline](/docs/concepts/pipeline/).
 
 Each service is executed inside an ephemeral [Docker container](https://www.docker.com/resources/what-container) and starts at the beginning of a pipeline.
 
@@ -39,7 +39,7 @@ This component is stored in the configured Vela backend in the `services` table.
 
 ## References
 
-* [API](/docs/api/service)
-* [CLI](/docs/cli/service)
-* SDK
-  * [Go](/docs/sdk/go/service)
+- [API](/docs/api/service)
+- [CLI](/docs/cli/service)
+- SDK
+  - [Go](/docs/sdk/go/service)

--- a/content/concepts/system/step.md
+++ b/content/concepts/system/step.md
@@ -7,7 +7,7 @@ description: >
 
 The `step` component is part of the core system components for Vela.
 
-A `step` is defined as a sequential, execution instruction for a [pipeline](/docs/concepts/pipeline).
+A `step` is defined as a sequential, execution instruction for a [pipeline](/docs/concepts/pipeline/).
 
 Each step is executed inside an ephemeral [Docker container](https://www.docker.com/resources/what-container) and are always executed in the order they are defined.
 
@@ -40,7 +40,7 @@ This component is stored in the configured Vela backend in the `steps` table.
 
 ## References
 
-* [API](/docs/api/step)
-* [CLI](/docs/cli/step)
-* SDK
-  * [Go](/docs/sdk/go/step)
+- [API](/docs/api/step)
+- [CLI](/docs/cli/step)
+- SDK
+  - [Go](/docs/sdk/go/step)

--- a/content/sdk/go/repo/_index.md
+++ b/content/sdk/go/repo/_index.md
@@ -10,5 +10,5 @@ The below functions are available to operate on the `repo` resource.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}

--- a/content/sdk/go/service/_index.md
+++ b/content/sdk/go/service/_index.md
@@ -10,5 +10,5 @@ The below functions are available to operate on the `service` resource.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}

--- a/content/sdk/go/step/_index.md
+++ b/content/sdk/go/step/_index.md
@@ -10,5 +10,5 @@ The below functions are available to operate on the `step` resource.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication).
+To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
 {{% /alert %}}

--- a/content/usage/getting-started/authenticate.md
+++ b/content/usage/getting-started/authenticate.md
@@ -26,4 +26,4 @@ Please see authentication in the [API reference](/docs/api/authentication/).
 
 ## SDK
 
-Please see authentication in the [sdk reference](/docs/usage/reference/sdk/authentication).
+Please see authentication in the [sdk reference](/docs/sdk/go/authentication/).

--- a/content/usage/getting-started/authenticate.md
+++ b/content/usage/getting-started/authenticate.md
@@ -18,11 +18,11 @@ Navigate to your deployed instance and follow the OAuth workflow presented on th
 
 Please see authentication in the [CLI reference](/docs/cli/authentication).
 
-_If you have not yet installed the CLI, see [CLI install reference](/docs/cli/install) first._
+_If you have not yet installed the CLI, see [CLI install reference](/docs/cli/install/) first._
 
 ## API
 
-Please see authentication in the [API reference](/docs/api/authentication).
+Please see authentication in the [API reference](/docs/api/authentication/).
 
 ## SDK
 

--- a/content/usage/getting-started/roles.md
+++ b/content/usage/getting-started/roles.md
@@ -10,17 +10,17 @@ description: >
 At this time the only Source Control Provider is GitHub. So this documentation is tailored for those users.
 {{% /alert %}}
 
-Vela does not maintain any authentication (AuthN) or authorization (AuthZ) internally, but instead inherits its access from the source (version control) provider. More information on GitHub's access model can be found in their [documentation](https://help.github.com/en/articles/access-permissions-on-github).
+Vela does not maintain any authentication (AuthN) or authorization (AuthZ) internally, but instead inherits its access from the source (version control) provider. More information on GitHub's access model can be found in their [documentation](https://help.github.com/en/github/getting-started-with-github/access-permissions-on-github).
 
 Platform Roles:
 
-* Admin
+- Admin
 
 Source Provider Roles:
 
-* Admin
-* Write
-* Read
+- Admin
+- Write
+- Read
 
 ### Platform Roles
 
@@ -34,25 +34,25 @@ Admins within the GitHub organization have the option to use GitHub orgs to allo
 
 The **admin** role enables full access to the repository, which grants the following access levels for resources:
 
-| Access | Repo | Build | Step | Service | Log | Secret  |
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Write | Y | N | N | N | N | Y |
-| Read | Y | Y | Y | Y | Y | Y |
+| Access | Repo | Build | Step | Service | Log | Secret |
+| :----: | :--: | :---: | :--: | :-----: | :-: | :----: |
+| Write  |  Y   |   N   |  N   |    N    |  N  |   Y    |
+|  Read  |  Y   |   Y   |  Y   |    Y    |  Y  |   Y    |
 
 #### Write
 
 The **write** role enables read and write access to the repository, which grants the following access levels for resources:
 
-| Access | Repo | Build | Step | Service | Log | Secret  |
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Write | Y | N | N | N | N | N |
-| Read | Y | Y | Y | Y | Y | N |
+| Access | Repo | Build | Step | Service | Log | Secret |
+| :----: | :--: | :---: | :--: | :-----: | :-: | :----: |
+| Write  |  Y   |   N   |  N   |    N    |  N  |   N    |
+|  Read  |  Y   |   Y   |  Y   |    Y    |  Y  |   N    |
 
 #### Read
 
 The **read** role enables read access to the repository, which grants the following access levels for resources:
 
-| Access | Repo | Build | Step | Service | Log | Secret  |
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Write | N | N | N | N | N | N |
-| Read | Y | Y | Y | Y | Y | N |
+| Access | Repo | Build | Step | Service | Log | Secret |
+| :----: | :--: | :---: | :--: | :-----: | :-: | :----: |
+| Write  |  N   |   N   |  N   |    N    |  N  |   N    |
+|  Read  |  Y   |   Y   |  Y   |    Y    |  Y  |   N    |

--- a/content/usage/pipeline/steps/environment.md
+++ b/content/usage/pipeline/steps/environment.md
@@ -10,7 +10,7 @@ The environment declaration for a build step instructs Vela to insert the given 
 {{% alert title="Warning" color="warning" %}}
 You should not use environment for plugin parameters or secrets.
 
-Please see [parameters](../parameters) or [secrets](../secrets).
+Please see [parameters](../parameters/) or [secrets](../secrets/).
 {{% /alert %}}
 
 ```diff


### PR DESCRIPTION
- fix 404 links
  - includes link to email (turned into mailto: link)
- fix redirects - example of issue:
  ![image](https://user-images.githubusercontent.com/1301201/76964607-fd570600-68f0-11ea-8724-62aa47ed55c5.png)
