### PR TITLE
docs: fix links (part 2)

### DIFF
--- a/content/cli/build/_index.md
+++ b/content/cli/build/_index.md
@@ -12,5 +12,5 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}

--- a/content/cli/build/get.md
+++ b/content/cli/build/get.md
@@ -45,7 +45,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/build/restart.md
+++ b/content/cli/build/restart.md
@@ -45,7 +45,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/build/view.md
+++ b/content/cli/build/view.md
@@ -46,7 +46,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/config/_index.md
+++ b/content/cli/config/_index.md
@@ -12,5 +12,5 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}

--- a/content/cli/config/generate.md
+++ b/content/cli/config/generate.md
@@ -41,7 +41,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/config/remove.md
+++ b/content/cli/config/remove.md
@@ -41,7 +41,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/config/update.md
+++ b/content/cli/config/update.md
@@ -41,7 +41,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/config/view.md
+++ b/content/cli/config/view.md
@@ -26,7 +26,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/log/_index.md
+++ b/content/cli/log/_index.md
@@ -12,5 +12,5 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}

--- a/content/cli/log/view.md
+++ b/content/cli/log/view.md
@@ -45,7 +45,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/pipeline/_index.md
+++ b/content/cli/pipeline/_index.md
@@ -12,5 +12,5 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}

--- a/content/cli/pipeline/generate.md
+++ b/content/cli/pipeline/generate.md
@@ -36,7 +36,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/repo/_index.md
+++ b/content/cli/repo/_index.md
@@ -12,5 +12,5 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}

--- a/content/cli/repo/add.md
+++ b/content/cli/repo/add.md
@@ -51,7 +51,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/repo/chown.md
+++ b/content/cli/repo/chown.md
@@ -45,7 +45,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/repo/get.md
+++ b/content/cli/repo/get.md
@@ -34,7 +34,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/repo/remove.md
+++ b/content/cli/repo/remove.md
@@ -45,7 +45,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/repo/repair.md
+++ b/content/cli/repo/repair.md
@@ -45,7 +45,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/repo/update.md
+++ b/content/cli/repo/update.md
@@ -51,7 +51,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/repo/view.md
+++ b/content/cli/repo/view.md
@@ -45,7 +45,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/secret/_index.md
+++ b/content/cli/secret/_index.md
@@ -12,5 +12,5 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}

--- a/content/cli/secret/add.md
+++ b/content/cli/secret/add.md
@@ -54,7 +54,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/secret/get.md
+++ b/content/cli/secret/get.md
@@ -50,7 +50,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/secret/remove.md
+++ b/content/cli/secret/remove.md
@@ -50,7 +50,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/secret/update.md
+++ b/content/cli/secret/update.md
@@ -54,7 +54,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/secret/view.md
+++ b/content/cli/secret/view.md
@@ -51,7 +51,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/service/_index.md
+++ b/content/cli/service/_index.md
@@ -12,5 +12,5 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}

--- a/content/cli/service/get.md
+++ b/content/cli/service/get.md
@@ -46,7 +46,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/service/view.md
+++ b/content/cli/service/view.md
@@ -47,7 +47,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/step/_index.md
+++ b/content/cli/step/_index.md
@@ -12,5 +12,5 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}

--- a/content/cli/step/get.md
+++ b/content/cli/step/get.md
@@ -46,7 +46,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/step/view.md
+++ b/content/cli/step/view.md
@@ -47,7 +47,7 @@ This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
 
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/cli/validate.md
+++ b/content/cli/validate.md
@@ -26,7 +26,7 @@ COMING SOON!
 This section assumes you have already installed and setup the CLI.
 
 To install the CLI, please review the [installation documentation](/docs/cli/install/).
-To setup the CLI, please review the [authentication documentation](/docs/cli/authentication).
+To setup the CLI, please review the [authentication documentation](/docs/cli/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/concepts/infrastructure/server/compiler.md
+++ b/content/concepts/infrastructure/server/compiler.md
@@ -7,4 +7,4 @@ description: >
 
 The `compiler` component is one of the server components for Vela.
 
-This component defines the system Vela uses for transforming a [pipeline](/docs/concepts/pipeline/) into an executable representation for the [worker](/docs/concepts/infrastructure/worker).
+This component defines the system Vela uses for transforming a [pipeline](/docs/concepts/pipeline/) into an executable representation for the [worker](/docs/concepts/infrastructure/worker/).

--- a/content/concepts/infrastructure/server/queue.md
+++ b/content/concepts/infrastructure/server/queue.md
@@ -7,7 +7,7 @@ description: >
 
 The `queue` component is one of the server components for Vela.
 
-This component defines the system Vela uses for publishing workloads to be completed by a [worker](/docs/concepts/infrastructure/worker).
+This component defines the system Vela uses for publishing workloads to be completed by a [worker](/docs/concepts/infrastructure/worker/).
 
 ## Configuration
 
@@ -22,9 +22,10 @@ The following options are used to configure the component:
 
 {{% alert color="info" %}}
 All available options support `VELA_*` prefixes for the environment variables. For example:
-* `QUEUE_DRIVER` - type of client to control and operate queue
-* `VELA_QUEUE_DRIVER` - type of client to control and operate queue
-{{% /alert %}}
+
+- `QUEUE_DRIVER` - type of client to control and operate queue
+- `VELA_QUEUE_DRIVER` - type of client to control and operate queue
+  {{% /alert %}}
 
 #### Drivers
 

--- a/content/concepts/infrastructure/server/secret.md
+++ b/content/concepts/infrastructure/server/secret.md
@@ -7,7 +7,7 @@ description: >
 
 The `secret` component is one of the server components for Vela.
 
-This component defines the system Vela uses for storing and accessing [secrets](/docs/concepts/system/secret).
+This component defines the system Vela uses for storing and accessing [secrets](/docs/concepts/system/secret/).
 
 ## Configuration
 
@@ -21,6 +21,7 @@ The following options are used to configure the component:
 
 {{% alert color="info" %}}
 All available options support `VELA_*` prefixes for the environment variables. For example:
-* `SECRET_VAULT` - enables the Vault secret engine
-* `VELA_SECRET_VAULT` - enables the Vault secret engine
-{{% /alert %}}
+
+- `SECRET_VAULT` - enables the Vault secret engine
+- `VELA_SECRET_VAULT` - enables the Vault secret engine
+  {{% /alert %}}

--- a/content/concepts/pipeline/secrets/engine.md
+++ b/content/concepts/pipeline/secrets/engine.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the engine component for a secret.
 ---
 
-The `engine` component is a part of a [secret](/docs/concepts/pipeline/secrets) for Vela.
+The `engine` component is a part of a [secret](/docs/concepts/pipeline/secrets/) for Vela.
 
 This declaration allows you to provide the name of the storage backend to fetch the secret from.
 
@@ -70,10 +70,12 @@ steps:
 
 {{% alert color="info" %}}
 This pipeline will allow the following secrets to be referenced:
-* `username`
-* `password`
+
+- `username`
+- `password`
 
 This pipeline will also add the following environment variables to the `test` step:
-* `USERNAME=<value>`
-* `PASSWORD=<value>`
-{{% /alert %}}
+
+- `USERNAME=<value>`
+- `PASSWORD=<value>`
+  {{% /alert %}}

--- a/content/concepts/pipeline/secrets/key.md
+++ b/content/concepts/pipeline/secrets/key.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the key component for a secret.
 ---
 
-The `key` component is a part of a [secret](/docs/concepts/pipeline/secrets) for Vela.
+The `key` component is a part of a [secret](/docs/concepts/pipeline/secrets/) for Vela.
 
 This declaration allows you to provide the path to the secret to fetch from the storage backend.
 
@@ -47,10 +47,12 @@ steps:
 
 {{% alert color="info" %}}
 This pipeline will allow the following secrets to be referenced:
-* `username`
-* `password`
+
+- `username`
+- `password`
 
 This pipeline will also add the following environment variables to the `test` step:
-* `USERNAME=<value>`
-* `PASSWORD=<value>`
-{{% /alert %}}
+
+- `USERNAME=<value>`
+- `PASSWORD=<value>`
+  {{% /alert %}}

--- a/content/concepts/pipeline/secrets/type.md
+++ b/content/concepts/pipeline/secrets/type.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the type component for a secret.
 ---
 
-The `type` component is a part of a [secret](/docs/concepts/pipeline/secrets) for Vela.
+The `type` component is a part of a [secret](/docs/concepts/pipeline/secrets/) for Vela.
 
 This declaration allows you to provide the type of secret to fetch from the storage backend.
 
@@ -83,10 +83,12 @@ steps:
 
 {{% alert color="info" %}}
 This pipeline will allow the following secrets to be referenced:
-* `username`
-* `password`
+
+- `username`
+- `password`
 
 This pipeline will also add the following environment variables to the `test` step:
-* `USERNAME=<value>`
-* `PASSWORD=<value>`
-{{% /alert %}}
+
+- `USERNAME=<value>`
+- `PASSWORD=<value>`
+  {{% /alert %}}

--- a/content/concepts/pipeline/services/entrypoint.md
+++ b/content/concepts/pipeline/services/entrypoint.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the entrypoint component for a service.
 ---
 
-The `entrypoint` component is a part of a [service](/docs/concepts/pipeline/services) for Vela.
+The `entrypoint` component is a part of a [service](/docs/concepts/pipeline/services/) for Vela.
 
 This declaration allows you to provide the command to execute inside the container.
 

--- a/content/concepts/pipeline/services/environment.md
+++ b/content/concepts/pipeline/services/environment.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the environment component for a service.
 ---
 
-The `environment` component is a part of a [service](/docs/concepts/pipeline/services) for Vela.
+The `environment` component is a part of a [service](/docs/concepts/pipeline/services/) for Vela.
 
 This declaration allows you to provide variables injected into the container environment.
 
@@ -47,7 +47,7 @@ The following environment variables are injected into every service:
 #### Build Environment Variables
 
 | Key                  | Value                                                                                    | Explanation                                                         |
-| ---------------------| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| -------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
 | `BUILD_AUTHOR`       | `octocat`                                                                                | author from the source commit                                       |
 | `BUILD_AUTHOR_EMAIL` | `octocat@github.com`                                                                     | author email from the source commit                                 |
 | `BUILD_BRANCH`       | `master`                                                                                 | branch from the source commit                                       |
@@ -70,9 +70,10 @@ The following environment variables are injected into every service:
 | `BUILD_TAG`          | `v1.0.0`                                                                                 | tag is populated from the source reference                          |
 
 {{% alert color="info" %}}
-* `BUILD_LINK` is not populated if the Vela server is configured to run headless (no UI).
-* `BUILD_TAG` is only populated during `tag` events.
-{{% /alert %}}
+
+- `BUILD_LINK` is not populated if the Vela server is configured to run headless (no UI).
+- `BUILD_TAG` is only populated during `tag` events.
+  {{% /alert %}}
 
 #### Vela Environment Variables
 

--- a/content/concepts/pipeline/services/image.md
+++ b/content/concepts/pipeline/services/image.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the image component for a service.
 ---
 
-The `image` component is a part of a [service](/docs/concepts/pipeline/services) for Vela.
+The `image` component is a part of a [service](/docs/concepts/pipeline/services/) for Vela.
 
 This declaration allows you to provide the [Docker image](https://docs.docker.com/engine/docker-overview/#images) used to create the ephemeral container.
 

--- a/content/concepts/pipeline/services/ports.md
+++ b/content/concepts/pipeline/services/ports.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the ports component for a service.
 ---
 
-The `ports` component is a part of a [service](/docs/concepts/pipeline/services) for Vela.
+The `ports` component is a part of a [service](/docs/concepts/pipeline/services/) for Vela.
 
 This declaration allows you to provide a list of ports to map for the container in the pipeline.
 

--- a/content/concepts/pipeline/services/pull.md
+++ b/content/concepts/pipeline/services/pull.md
@@ -5,9 +5,9 @@ description: >
   This section contains information on the pull component for a service.
 ---
 
-The `pull` component is a part of a [service](/docs/concepts/pipeline/services) for Vela.
+The `pull` component is a part of a [service](/docs/concepts/pipeline/services/) for Vela.
 
-This declaration allows you to automatically upgrade to the latest version of the [image](/docs/concepts/pipeline/services/image).
+This declaration allows you to automatically upgrade to the latest version of the [image](/docs/concepts/pipeline/services/image/).
 
 {{% alert color="info" %}}
 Vela will always attempt to pull from its existing cache for images.

--- a/content/concepts/pipeline/stages/_index.md
+++ b/content/concepts/pipeline/stages/_index.md
@@ -13,7 +13,7 @@ This declaration allows you to provide parallel, execution instructions for a pi
 A single, ephemeral run of a pipeline is known as a [build](/docs/concepts/system/build/).
 {{% /alert %}}
 
-Stages are always executed, in parallel, and are comprised of one or many [steps](/docs/concepts/pipeline/steps).
+Stages are always executed, in parallel, and are comprised of one or many [steps](/docs/concepts/pipeline/steps/).
 
 ## Fields
 

--- a/content/concepts/pipeline/stages/needs.md
+++ b/content/concepts/pipeline/stages/needs.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the needs component for a stage.
 ---
 
-The `needs` component is a part of a [stage](/docs/concepts/pipeline/stages) for Vela.
+The `needs` component is a part of a [stage](/docs/concepts/pipeline/stages/) for Vela.
 
 This declaration allows you to provide other stages that must complete before starting the current one.
 

--- a/content/concepts/pipeline/stages/steps.md
+++ b/content/concepts/pipeline/stages/steps.md
@@ -5,12 +5,12 @@ description: >
   This section contains information on the steps component for a stage.
 ---
 
-The `steps` component is a part of a [stage](/docs/concepts/pipeline/stages) for Vela.
+The `steps` component is a part of a [stage](/docs/concepts/pipeline/stages/) for Vela.
 
 This declaration allows you to provide sequential, execution instructions for a stage.
 
 {{% alert color="info" %}}
-For more information, you can visit the [steps documentation](/docs/concepts/pipeline/steps).
+For more information, you can visit the [steps documentation](/docs/concepts/pipeline/steps/).
 {{% /alert %}}
 
 ## Syntax

--- a/content/concepts/pipeline/steps/_index.md
+++ b/content/concepts/pipeline/steps/_index.md
@@ -18,7 +18,7 @@ Steps are always executed, in the order they are defined, inside an ephemeral [D
 If the container returns a non-zero exit code, the build immediately terminates and returns a failure status.
 
 {{% alert color="info" %}}
-To run `steps` in parallel, you can visit the [stages documentation](/docs/concepts/pipeline/stages).
+To run `steps` in parallel, you can visit the [stages documentation](/docs/concepts/pipeline/stages/).
 {{% /alert %}}
 
 ## Fields

--- a/content/concepts/pipeline/steps/commands.md
+++ b/content/concepts/pipeline/steps/commands.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the commands component for a step.
 ---
 
-The `commands` component is a part of a [step](/docs/concepts/pipeline/steps) for Vela.
+The `commands` component is a part of a [step](/docs/concepts/pipeline/steps/) for Vela.
 
 This declaration allows you to provide execution instructions to run inside the container.
 

--- a/content/concepts/pipeline/steps/detach.md
+++ b/content/concepts/pipeline/steps/detach.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the detach component for a step.
 ---
 
-The `detach` component is a part of a [step](/docs/concepts/pipeline/steps) for Vela.
+The `detach` component is a part of a [step](/docs/concepts/pipeline/steps/) for Vela.
 
 This declaration allows you to run the container in a detached (headless) state.
 

--- a/content/concepts/pipeline/steps/entrypoint.md
+++ b/content/concepts/pipeline/steps/entrypoint.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the entrypoint component for a step.
 ---
 
-The `entrypoint` component is a part of a [step](/docs/concepts/pipeline/steps) for Vela.
+The `entrypoint` component is a part of a [step](/docs/concepts/pipeline/steps/) for Vela.
 
 This declaration allows you to provide the command to execute inside the container.
 

--- a/content/concepts/pipeline/steps/environment.md
+++ b/content/concepts/pipeline/steps/environment.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the environment component for a step.
 ---
 
-The `environment` component is a part of a [step](/docs/concepts/pipeline/steps) for Vela.
+The `environment` component is a part of a [step](/docs/concepts/pipeline/steps/) for Vela.
 
 This declaration allows you to provide variables injected into the container environment.
 
@@ -50,7 +50,7 @@ The following environment variables are injected into every step:
 #### Build Environment Variables
 
 | Key                  | Value                                                                                    | Explanation                                                         |
-| ---------------------| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| -------------------- | ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
 | `BUILD_AUTHOR`       | `octocat`                                                                                | author from the source commit                                       |
 | `BUILD_AUTHOR_EMAIL` | `octocat@github.com`                                                                     | author email from the source commit                                 |
 | `BUILD_BRANCH`       | `master`                                                                                 | branch from the source commit                                       |
@@ -73,9 +73,10 @@ The following environment variables are injected into every step:
 | `BUILD_TAG`          | `v1.0.0`                                                                                 | tag is populated from the source reference                          |
 
 {{% alert color="info" %}}
-* `BUILD_LINK` is not populated if the Vela server is configured to run headless (no UI).
-* `BUILD_TAG` is only populated during `tag` events.
-{{% /alert %}}
+
+- `BUILD_LINK` is not populated if the Vela server is configured to run headless (no UI).
+- `BUILD_TAG` is only populated during `tag` events.
+  {{% /alert %}}
 
 #### Vela Environment Variables
 

--- a/content/concepts/pipeline/steps/image.md
+++ b/content/concepts/pipeline/steps/image.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the image component for a step.
 ---
 
-The `image` component is a part of a [step](/docs/concepts/pipeline/steps) for Vela.
+The `image` component is a part of a [step](/docs/concepts/pipeline/steps/) for Vela.
 
 This declaration allows you to provide the [Docker image](https://docs.docker.com/engine/docker-overview/#images) used to create the ephemeral container.
 

--- a/content/concepts/pipeline/steps/parameters.md
+++ b/content/concepts/pipeline/steps/parameters.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the parameters component for a step.
 ---
 
-The `parameters` component is a part of a [step](/docs/concepts/pipeline/steps) for Vela.
+The `parameters` component is a part of a [step](/docs/concepts/pipeline/steps/) for Vela.
 
 This declaration allows you to provide extra configuration variables for a plugin.
 
@@ -30,6 +30,7 @@ steps:
 
 {{% alert color="info" %}}
 This pipeline will add the following environment variables to the `plugin` step:
-* `PARAMETER_REGISTRY=index.docker.io`
-* `PARAMETER_REPO=index.docker.io/octocat/hello-world`
-{{% /alert %}}
+
+- `PARAMETER_REGISTRY=index.docker.io`
+- `PARAMETER_REPO=index.docker.io/octocat/hello-world`
+  {{% /alert %}}

--- a/content/concepts/pipeline/steps/privileged.md
+++ b/content/concepts/pipeline/steps/privileged.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the privileged component for a step.
 ---
 
-The `privileged` component is a part of a [step](/docs/concepts/pipeline/steps) for Vela.
+The `privileged` component is a part of a [step](/docs/concepts/pipeline/steps/) for Vela.
 
 This declaration allows you to run the container with extra privileges.
 

--- a/content/concepts/pipeline/steps/pull.md
+++ b/content/concepts/pipeline/steps/pull.md
@@ -5,9 +5,9 @@ description: >
   This section contains information on the pull component for a step.
 ---
 
-The `pull` component is a part of a [step](/docs/concepts/pipeline/steps) for Vela.
+The `pull` component is a part of a [step](/docs/concepts/pipeline/steps/) for Vela.
 
-This declaration allows you to automatically upgrade to the latest version of the [image](/docs/concepts/pipeline/steps/image).
+This declaration allows you to automatically upgrade to the latest version of the [image](/docs/concepts/pipeline/steps/image/).
 
 {{% alert color="info" %}}
 Vela will always attempt to pull from its existing cache for images.

--- a/content/concepts/pipeline/steps/ruleset.md
+++ b/content/concepts/pipeline/steps/ruleset.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the ruleset component for a step.
 ---
 
-The `ruleset` component is a part of a [step](/docs/concepts/pipeline/steps) for Vela.
+The `ruleset` component is a part of a [step](/docs/concepts/pipeline/steps/) for Vela.
 
 This declaration allows you to provide conditions to limit the execution of the container.
 
@@ -54,9 +54,10 @@ steps:
 
 {{% alert color="info" %}}
 This pipeline will limit the execution of the `test` and `build` steps to:
-* builds with a branch of `master`
-* builds with an event of `push`
-{{% /alert %}}
+
+- builds with a branch of `master`
+- builds with an event of `push`
+  {{% /alert %}}
 
 ## Advanced
 
@@ -103,10 +104,12 @@ steps:
 
 {{% alert color="info" %}}
 This pipeline will limit the execution of the `test` step to:and `build` steps to:
-* builds with a branch of `master`
-* builds with an event of `push`
+
+- builds with a branch of `master`
+- builds with an event of `push`
 
 This pipeline will also limit the execution of the `build` step to:
-* builds without a branch of `master`
-* builds without an event of `push`
-{{% /alert %}}
+
+- builds without a branch of `master`
+- builds without an event of `push`
+  {{% /alert %}}

--- a/content/concepts/pipeline/steps/secrets.md
+++ b/content/concepts/pipeline/steps/secrets.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the secrets component for a step.
 ---
 
-The `secrets` component is a part of a [step](/docs/concepts/pipeline/steps) for Vela.
+The `secrets` component is a part of a [step](/docs/concepts/pipeline/steps/) for Vela.
 
 This declaration allows you to provide sensitive variables injected into the container environment.
 
@@ -45,8 +45,9 @@ steps:
 
 {{% alert color="info" %}}
 This pipeline will add the following environment variables to the `test` and `build` steps:
-* `GIT_USERNAME=<value>`
-* `GIT_PASSWORD=<value>`
+
+- `GIT_USERNAME=<value>`
+- `GIT_PASSWORD=<value>`
 
 This pipeline will also execute the `test` step first, then run the `build` step.
 {{% /alert %}}
@@ -102,8 +103,9 @@ steps:
 
 {{% alert color="info" %}}
 This pipeline will add the following environment variables to the `test` and `build` steps:
-* `GIT_USERNAME=<value>`
-* `GIT_PASSWORD=<value>`
+
+- `GIT_USERNAME=<value>`
+- `GIT_PASSWORD=<value>`
 
 This pipeline will also execute the `test` step first, then run the `build` step.
 {{% /alert %}}

--- a/content/concepts/pipeline/steps/template.md
+++ b/content/concepts/pipeline/steps/template.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the template component for a step.
 ---
 
-The `template` component is a part of a [step](/docs/concepts/pipeline/steps) for Vela.
+The `template` component is a part of a [step](/docs/concepts/pipeline/steps/) for Vela.
 
 This declaration allows you to provide the name of template to expand in the pipeline.
 
@@ -13,10 +13,10 @@ This declaration allows you to provide the name of template to expand in the pip
 
 The following fields are used to configure the component:
 
-| Name     | Description                                        | Required |
-| -------- | -------------------------------------------------- | -------- |
-| `name`   | unique identifier for the template in the pipeline | `true`   |
-| `vars`   | variables injected into the template               | `false`  |
+| Name   | Description                                        | Required |
+| ------ | -------------------------------------------------- | -------- |
+| `name` | unique identifier for the template in the pipeline | `true`   |
+| `vars` | variables injected into the template               | `false`  |
 
 ## Syntax
 

--- a/content/concepts/pipeline/templates/_index.md
+++ b/content/concepts/pipeline/templates/_index.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the template component for a step.
 ---
 
-The `template` component is a part of a [step](/docs/concepts/pipeline/steps) for Vela.
+The `template` component is a part of a [step](/docs/concepts/pipeline/steps/) for Vela.
 
 This declaration allows you to provide the name of template to expand in the pipeline.
 

--- a/content/concepts/pipeline/templates/source.md
+++ b/content/concepts/pipeline/templates/source.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the source component for a template.
 ---
 
-The `source` component is a part of a [template](/docs/concepts/pipeline/templates) for Vela.
+The `source` component is a part of a [template](/docs/concepts/pipeline/templates/) for Vela.
 
 This declaration allows you to provide the path to the template in the remote system.
 

--- a/content/concepts/pipeline/templates/type.md
+++ b/content/concepts/pipeline/templates/type.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the type component for a template.
 ---
 
-The `type` component is a part of a [template](/docs/concepts/pipeline/templates) for Vela.
+The `type` component is a part of a [template](/docs/concepts/pipeline/templates/) for Vela.
 
 This declaration allows you to provide the type of template provided from the remote system.
 

--- a/content/concepts/system/build.md
+++ b/content/concepts/system/build.md
@@ -9,10 +9,10 @@ The `build` component is part of the core system components for Vela.
 
 A `build` is defined as a single, ephemeral execution of a [pipeline](/docs/concepts/pipeline/).
 
-A build is comprised of one or many [services](/docs/concepts/system/service) and [steps](/docs/concepts/system/step) that contain the instructions to execute from the pipeline.
+A build is comprised of one or many [services](/docs/concepts/system/service/) and [steps](/docs/concepts/system/step/) that contain the instructions to execute from the pipeline.
 
 {{% alert color="info" %}}
-A build is typically created from a [hook](/docs/concepts/system/hook) triggered by a [repo](/docs/concepts/system/repo) in the source control provider.
+A build is typically created from a [hook](/docs/concepts/system/hook/) triggered by a [repo](/docs/concepts/system/repo/) in the source control provider.
 {{% /alert %}}
 
 ## Fields

--- a/content/concepts/system/hook.md
+++ b/content/concepts/system/hook.md
@@ -7,7 +7,7 @@ description: >
 
 The `hook` component is part of the core system components for Vela.
 
-A `hook` is defined as a single, webhook object received from a [repo](/docs/concepts/system/repo) in the source control provider prompting Vela to perform an action.
+A `hook` is defined as a single, webhook object received from a [repo](/docs/concepts/system/repo/) in the source control provider prompting Vela to perform an action.
 
 In most cases, processing a hook involves fetching the [pipeline](/docs/concepts/pipeline/) from the repo and triggering a [build](/docs/concepts/system/build/).
 
@@ -44,6 +44,6 @@ This component is stored in the configured Vela backend in the `hooks` table.
 ## References
 
 - [API](/docs/api/build/)
-- [CLI](/docs/cli/hook)
+- [CLI](/docs/cli/hook/)
 - SDK
-  - [Go](/docs/sdk/go/hook)
+  - [Go](/docs/sdk/go/hook/)

--- a/content/concepts/system/log.md
+++ b/content/concepts/system/log.md
@@ -29,12 +29,12 @@ This component is stored in the configured Vela backend in the `logs` table.
 ## References
 
 - API
-  - [Build](/docs/api/build/logs)
-  - [Service](/docs/api/service/logs)
-  - [Step](/docs/api/step/logs)
-- [CLI](/docs/cli/log)
+  - [Build](/docs/api/build/logs/)
+  - [Service](/docs/api/service/logs/)
+  - [Step](/docs/api/step/logs/)
+- [CLI](/docs/cli/log/)
 - SDK
   - Go
-    - [Build](/docs/sdk/go/build/logs)
-    - [Service](/docs/sdk/go/service/logs)
-    - [Step](/docs/sdk/go/step/logs)
+    - [Build](/docs/sdk/go/build/logs/)
+    - [Service](/docs/sdk/go/service/logs/)
+    - [Step](/docs/sdk/go/step/logs/)

--- a/content/concepts/system/repo.md
+++ b/content/concepts/system/repo.md
@@ -7,11 +7,10 @@ description: >
 
 The `repo` component is part of the core system components for Vela.
 
-A `repo` is defined as the upstream dependency from the source control provider used to store code and trigger [hooks](/docs/concepts/system/hook) to Vela.
+A `repo` is defined as the upstream dependency from the source control provider used to store code and trigger [hooks](/docs/concepts/system/hook/) to Vela.
 
 {{% alert color="info" %}}
-From [GitHub's repository documentation](
-https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-repositories):
+From [GitHub's repository documentation](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-repositories):
 
 > A repository is like a folder for your project. Your project's repository contains all of your project's files and stores each file's revision history. You can also discuss and manage your project's work within the repository.
 
@@ -48,7 +47,7 @@ This component is stored in the configured Vela backend in the `repos` table.
 
 ## References
 
-* [API](/docs/api/repo)
-* [CLI](/docs/cli/repo)
-* SDK
-  * [Go](/docs/sdk/go/repo)
+- [API](/docs/api/repo/)
+- [CLI](/docs/cli/repo/)
+- SDK
+  - [Go](/docs/sdk/go/repo/)

--- a/content/concepts/system/secret.md
+++ b/content/concepts/system/secret.md
@@ -11,12 +11,13 @@ A `secret` is defined as a piece of sensitive data or information that you want 
 
 {{% alert color="info" %}}
 The following list are some examples of secrets:
-* API keys
-* certificates
-* passwords
-* tokens
-* much, much more...
-{{% /alert %}}
+
+- API keys
+- certificates
+- passwords
+- tokens
+- much, much more...
+  {{% /alert %}}
 
 ## Fields
 
@@ -77,7 +78,7 @@ This secret type requires you to be a member of the team in the organization.
 
 ## References
 
-* [API](/docs/api/secret)
-* [CLI](/docs/cli/secret)
-* SDK
-  * [Go](/docs/sdk/go/secret)
+- [API](/docs/api/secret/)
+- [CLI](/docs/cli/secret/)
+- SDK
+  - [Go](/docs/sdk/go/secret/)

--- a/content/concepts/system/service.md
+++ b/content/concepts/system/service.md
@@ -39,7 +39,7 @@ This component is stored in the configured Vela backend in the `services` table.
 
 ## References
 
-- [API](/docs/api/service)
-- [CLI](/docs/cli/service)
+- [API](/docs/api/service/)
+- [CLI](/docs/cli/service/)
 - SDK
-  - [Go](/docs/sdk/go/service)
+  - [Go](/docs/sdk/go/service/)

--- a/content/concepts/system/step.md
+++ b/content/concepts/system/step.md
@@ -40,7 +40,7 @@ This component is stored in the configured Vela backend in the `steps` table.
 
 ## References
 
-- [API](/docs/api/step)
-- [CLI](/docs/cli/step)
+- [API](/docs/api/step/)
+- [CLI](/docs/cli/step/)
 - SDK
-  - [Go](/docs/sdk/go/step)
+  - [Go](/docs/sdk/go/step/)

--- a/content/concepts/system/user.md
+++ b/content/concepts/system/user.md
@@ -29,7 +29,7 @@ This component is stored in the configured Vela backend in the `users` table.
 
 ## References
 
-* [API](/docs/api/user)
-* [CLI](/docs/cli/user)
-* SDK
-  * [Go](/docs/sdk/go/user)
+- [API](/docs/api/user/)
+- [CLI](/docs/cli/user/)
+- SDK
+  - [Go](/docs/sdk/go/user/)

--- a/content/sdk/go/build/_index.md
+++ b/content/sdk/go/build/_index.md
@@ -10,5 +10,5 @@ The below functions are available to operate on the `build` resource.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}

--- a/content/sdk/go/build/add.md
+++ b/content/sdk/go/build/add.md
@@ -41,7 +41,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-BuildService-Add).

--- a/content/sdk/go/build/get.md
+++ b/content/sdk/go/build/get.md
@@ -19,7 +19,7 @@ For more information, you can view our [go documentation](https://godoc.org/gith
 
 The following parameters are used to configure the function:
 
-| Name   | Description                |
+| Name   | Description                |
 | ------ | -------------------------- |
 | `org`  | name of organization       |
 | `repo` | name of repository         |
@@ -41,7 +41,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-BuildService-GetAll).

--- a/content/sdk/go/build/logs.md
+++ b/content/sdk/go/build/logs.md
@@ -41,7 +41,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-BuildService-GetLogs).

--- a/content/sdk/go/build/remove.md
+++ b/content/sdk/go/build/remove.md
@@ -41,7 +41,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-BuildService-Remove).

--- a/content/sdk/go/build/restart.md
+++ b/content/sdk/go/build/restart.md
@@ -41,7 +41,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-BuildService-Restart).

--- a/content/sdk/go/build/update.md
+++ b/content/sdk/go/build/update.md
@@ -41,7 +41,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-BuildService-Update).

--- a/content/sdk/go/build/view.md
+++ b/content/sdk/go/build/view.md
@@ -41,7 +41,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-BuildService-Get).

--- a/content/sdk/go/repo/add.md
+++ b/content/sdk/go/repo/add.md
@@ -39,7 +39,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-RepoService-Add).

--- a/content/sdk/go/repo/chown.md
+++ b/content/sdk/go/repo/chown.md
@@ -40,7 +40,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-RepoService-Chown).

--- a/content/sdk/go/repo/get.md
+++ b/content/sdk/go/repo/get.md
@@ -19,7 +19,7 @@ For more information, you can view our [go documentation](https://godoc.org/gith
 
 The following parameters are used to configure the function:
 
-| Name  | Description               |
+| Name  | Description               |
 | ----- | ------------------------- |
 | `opt` | options for listing repos |
 
@@ -39,7 +39,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-RepoService-GetAll).

--- a/content/sdk/go/repo/remove.md
+++ b/content/sdk/go/repo/remove.md
@@ -19,10 +19,10 @@ For more information, you can view our [go documentation](https://godoc.org/gith
 
 The following parameters are used to configure the endpoint:
 
-| Name    | Description          |
-| ------- | -------------------- |
-| `org`   | name of organization |
-| `repo`  | name of repository   |
+| Name   | Description          |
+| ------ | -------------------- |
+| `org`  | name of organization |
+| `repo` | name of repository   |
 
 ## Permissions
 
@@ -40,7 +40,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-RepoService-Remove).

--- a/content/sdk/go/repo/repair.md
+++ b/content/sdk/go/repo/repair.md
@@ -40,7 +40,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-RepoService-Repair).

--- a/content/sdk/go/repo/update.md
+++ b/content/sdk/go/repo/update.md
@@ -23,7 +23,7 @@ The following parameters are used to configure the endpoint:
 | ------ | -------------------- |
 | `org`  | name of organization |
 | `repo` | name of repository   |
-| `r`    | information on repo |
+| `r`    | information on repo  |
 
 ## Permissions
 
@@ -41,7 +41,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-RepoService-Update).

--- a/content/sdk/go/repo/view.md
+++ b/content/sdk/go/repo/view.md
@@ -19,10 +19,10 @@ For more information, you can view our [go documentation](https://godoc.org/gith
 
 The following parameters are used to configure the endpoint:
 
-| Name    | Description          |
-| ------- | -------------------- |
-| `org`   | name of organization |
-| `repo`  | name of repository   |
+| Name   | Description          |
+| ------ | -------------------- |
+| `org`  | name of organization |
+| `repo` | name of repository   |
 
 ## Permissions
 
@@ -40,7 +40,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-RepoService-Get).

--- a/content/sdk/go/secret/_index.md
+++ b/content/sdk/go/secret/_index.md
@@ -10,5 +10,5 @@ The below functions are available to operate on the `secret` resource.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}

--- a/content/sdk/go/secret/add.md
+++ b/content/sdk/go/secret/add.md
@@ -43,7 +43,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-SecretService-Add).

--- a/content/sdk/go/secret/get.md
+++ b/content/sdk/go/secret/get.md
@@ -43,7 +43,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-SecretService-GetAll).

--- a/content/sdk/go/secret/remove.md
+++ b/content/sdk/go/secret/remove.md
@@ -43,7 +43,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-SecretService-Remove).

--- a/content/sdk/go/secret/update.md
+++ b/content/sdk/go/secret/update.md
@@ -43,7 +43,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-SecretService-Update).

--- a/content/sdk/go/secret/view.md
+++ b/content/sdk/go/secret/view.md
@@ -43,7 +43,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-SecretService-Get).

--- a/content/sdk/go/service/add.md
+++ b/content/sdk/go/service/add.md
@@ -42,7 +42,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-SvcService-Add).

--- a/content/sdk/go/service/get.md
+++ b/content/sdk/go/service/get.md
@@ -42,7 +42,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-SvcService-GetAll).

--- a/content/sdk/go/service/logs.md
+++ b/content/sdk/go/service/logs.md
@@ -41,7 +41,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-LogService-GetService).

--- a/content/sdk/go/service/remove.md
+++ b/content/sdk/go/service/remove.md
@@ -42,7 +42,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-SvcService-Remove).

--- a/content/sdk/go/service/update.md
+++ b/content/sdk/go/service/update.md
@@ -42,7 +42,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-SvcService-Update).

--- a/content/sdk/go/service/view.md
+++ b/content/sdk/go/service/view.md
@@ -42,7 +42,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-SvcService-Get).

--- a/content/sdk/go/step/add.md
+++ b/content/sdk/go/step/add.md
@@ -42,7 +42,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-StepService-Add).

--- a/content/sdk/go/step/get.md
+++ b/content/sdk/go/step/get.md
@@ -42,7 +42,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-StepService-GetAll).

--- a/content/sdk/go/step/logs.md
+++ b/content/sdk/go/step/logs.md
@@ -42,7 +42,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-LogService-GetStep).

--- a/content/sdk/go/step/remove.md
+++ b/content/sdk/go/step/remove.md
@@ -42,7 +42,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-StepService-Remove).

--- a/content/sdk/go/step/update.md
+++ b/content/sdk/go/step/update.md
@@ -42,7 +42,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-StepService-Update).

--- a/content/sdk/go/step/view.md
+++ b/content/sdk/go/step/view.md
@@ -42,7 +42,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate with the SDK.
 
-To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication).
+To authenticate with the SDK, please review the [authentication documentation](/docs/sdk/authentication/).
 {{% /alert %}}
 
 You can find an example of this function [here](https://godoc.org/github.com/go-vela/sdk-go/vela#example-StepService-Get).

--- a/content/usage/getting-started/authenticate.md
+++ b/content/usage/getting-started/authenticate.md
@@ -16,7 +16,7 @@ Navigate to your deployed instance and follow the OAuth workflow presented on th
 
 ## CLI
 
-Please see authentication in the [CLI reference](/docs/cli/authentication).
+Please see authentication in the [CLI reference](/docs/cli/authentication/).
 
 _If you have not yet installed the CLI, see [CLI install reference](/docs/cli/install/) first._
 

--- a/themes/docsy/userguide/content/en/docs/Examples/_index.md
+++ b/themes/docsy/userguide/content/en/docs/Examples/_index.md
@@ -11,17 +11,17 @@ One of the best ways to see what Docsy can do, and learn how to configure a site
 
 Example sites that have low to no customization:
 
-| Site  | Repo (if public)  |
-|---|---|
-| [This Docsy documentation site](/docs) | https://github.com/google/docsy |
-| ["Goldydocs" - a Docsy example site](https://example.docsy.dev) | https://github.com/google/docsy-example  |
-| https://www.kubeflow.org/  | https://github.com/kubeflow/website  |
-| https://agones.dev/site/ | https://github.com/GoogleCloudPlatform/agones/tree/master/site |
+| Site                                                            | Repo (if public)                                               |
+| --------------------------------------------------------------- | -------------------------------------------------------------- |
+| [This Docsy documentation site](/docs/)                         | https://github.com/google/docsy                                |
+| ["Goldydocs" - a Docsy example site](https://example.docsy.dev) | https://github.com/google/docsy-example                        |
+| https://www.kubeflow.org/                                       | https://github.com/kubeflow/website                            |
+| https://agones.dev/site/                                        | https://github.com/GoogleCloudPlatform/agones/tree/master/site |
 
 ## Customized Docsy examples
 
 Example sites that include a moderate to high amount of customization:
 
-| Site  | Repo (if public)  |
-|---|---|
+| Site                           | Repo (if public)                                                       |
+| ------------------------------ | ---------------------------------------------------------------------- |
 | [Knative](https://knative.dev) | https://github.com/knative/docs and https://github.com/knative/website |

--- a/themes/docsy/userguide/content/en/docs/_index.md
+++ b/themes/docsy/userguide/content/en/docs/_index.md
@@ -1,4 +1,3 @@
-
 ---
 title: "Welcome to Docsy"
 linkTitle: "Documentation"
@@ -11,17 +10,17 @@ Welcome to the Docsy theme user guide! This guide shows you how to get started c
 
 ## What is Docsy?
 
-Docsy is a theme for the [Hugo](https://gohugo.io/) static site generator that's specifically designed for technical 
-documentation sets and has a lot of best practices built in. Use Docsy to get a working and reliable documentation 
-site up and running fast, and then get back to focusing on great content for your users. 
-[Learn more about Docsy](/about).
+Docsy is a theme for the [Hugo](https://gohugo.io/) static site generator that's specifically designed for technical
+documentation sets and has a lot of best practices built in. Use Docsy to get a working and reliable documentation
+site up and running fast, and then get back to focusing on great content for your users.
+[Learn more about Docsy](/about/).
 
 In addition to the theme itself, we provide an [example site](https://github.com/google/docsy-example) that uses lots of Docsy features and has a useful skeleton site structure (with advice for what to put in it!) for a large technical documentation set. You can copy the entire site and edit it for your own projects, or just explore the site and its source to see what Docsy can do. The site you're currently reading also uses Docsy and is a useful example of a smaller Docsy docset: feel free to copy it or borrow from it if it suits your needs better than the "big" example.
 
 Docsy itself does **not** provide:
 
-* **Source hosting and management**: Our theme and site source files live on [GitHub](https://github.com/), which is the simplest approach for most projects. However, you can also keep your project files in [GitLab](https://about.gitlab.com/), [BitBucket](https://bitbucket.org/product), locally, or wherever you like. Be aware that where your source files live may affect the Docsy features you can use (such as letting users file documentation issues) and site deployment options.
-* **Site deployment**: You can find out about deployment options in [Previews and Deployment](./deployment/). This site uses [Netlify](https://www.netlify.com/). 
+- **Source hosting and management**: Our theme and site source files live on [GitHub](https://github.com/), which is the simplest approach for most projects. However, you can also keep your project files in [GitLab](https://about.gitlab.com/), [BitBucket](https://bitbucket.org/product), locally, or wherever you like. Be aware that where your source files live may affect the Docsy features you can use (such as letting users file documentation issues) and site deployment options.
+- **Site deployment**: You can find out about deployment options in [Previews and Deployment](./deployment/). This site uses [Netlify](https://www.netlify.com/).
 
 Docsy also doesn't actually generate your site's HTML files: that's Hugo's job! Hugo takes your Markdown or HTML doc source files and Docsy's theme files and builds them into a static site for deployment. You can find out more about Hugo and how it works in the [Hugo documentation](https://gohugo.io/documentation/).
 
@@ -31,8 +30,8 @@ Docsy is particularly useful for medium to large technical documentation sets wi
 
 If you have a smaller project with only a couple of pages of documentation and hence simpler navigation needs, Docsy may be too heavyweight a solution for you. Instead, consider:
 
-* A simpler Hugo or Jekyll theme: find out what's available in Github Pages' [built-in Jekyll options](https://pages.github.com/themes/) and the [Hugo theme gallery](https://themes.gohugo.io/).
-* A good README file that tells users what your project does and links to some examples.
+- A simpler Hugo or Jekyll theme: find out what's available in Github Pages' [built-in Jekyll options](https://pages.github.com/themes/) and the [Hugo theme gallery](https://themes.gohugo.io/).
+- A good README file that tells users what your project does and links to some examples.
 
 If you have a very large documentation project, our example site structure may not be sufficient either, though you can still use our theme, possibly with heavier customization.
 
@@ -41,5 +40,3 @@ If you'd like to use Docsy's layouts but prefer to use Jekyll, [vsoch](https://g
 ## Ready to get started?
 
 Find out how to build and serve your first site in [Getting Started](./getting-started/). Or visit the [example site](https://example.docsy.dev) and [its repo](https://github.com/google/docsy-example) and start exploring!
-
-


### PR DESCRIPTION
missed quite a few links that are doing unnecessary redirects.. used highly advanced regex this time to get all the missing ones. as always the markdown linter had to say a couple of things.