### PR TITLE
Reorder login arguments to avoid global strings

### DIFF
--- a/content/cli/authentication.md
+++ b/content/cli/authentication.md
@@ -29,10 +29,10 @@ Log in and capture the personal token:
 
 ```sh
 # Syntax
-vela --addr <vela server url> login
+vela login --addr <vela server url>
 
 # Example
-vela --addr https://vela-server.localhost login
+vela login --addr https://vela-server.localhost
 ```
 
 Generate the configuration file:


### PR DESCRIPTION
Resolves an issue introduced by:
https://github.com/go-vela/cli/commit/e1b69d8b8904fce1805a667f5714dbbe8455aa18#diff-d71c03cf6c8ea28837ae4dfa2eb2cc29L63