### PR TITLE
chore(plugins): add docker-promote to artifactory

### DIFF
--- a/content/plugins/registry/artifactory.md
+++ b/content/plugins/registry/artifactory.md
@@ -17,7 +17,7 @@ Sample of copying an artifact:
 ```yaml
 steps:
   - name: copy_artifacts
-    image: target/vela-artifactory:v0.1.0
+    image: target/vela-artifactory:v0.2.0
     pull: true
     parameters:
       action: copy
@@ -31,7 +31,7 @@ Sample of deleting an artifact:
 ```yaml
 steps:
   - name: delete_artifacts
-    image: target/vela-artifactory:v0.1.0
+    image: target/vela-artifactory:v0.2.0
     pull: true
     parameters:
       action: delete
@@ -44,7 +44,7 @@ Sample of setting properties on an artifact:
 ```yaml
 steps:
   - name: set_properties_artifacts
-    image: target/vela-artifactory:v0.1.0
+    image: target/vela-artifactory:v0.2.0
     pull: true
     parameters:
       action: set-prop
@@ -64,7 +64,7 @@ Sample of uploading an artifact:
 ```yaml
 steps:
   - name: upload_artifacts
-    image: target/vela-artifactory:v0.1.0
+    image: target/vela-artifactory:v0.2.0
     pull: true
     parameters:
       action: upload
@@ -81,7 +81,7 @@ Sample of pretending to upload an artifact:
 ```diff
 steps:
   - name: upload_artifacts
-    image: target/vela-artifactory:v0.1.0
+    image: target/vela-artifactory:v0.2.0
     pull: true
     parameters:
       action: upload
@@ -129,7 +129,7 @@ Users can use [Vela secrets](/docs/concepts/pipeline/secrets/) to substitute the
 ```diff
 steps:
   - name: copy_artifacts
-    image: target/vela-artifactory:v0.1.0
+    image: target/vela-artifactory:v0.2.0
     pull: true
 +   secrets: [ artifactory_username, artifactory_password ]
     parameters:

--- a/content/plugins/registry/artifactory.md
+++ b/content/plugins/registry/artifactory.md
@@ -94,6 +94,22 @@ steps:
       url: http://localhost:8081/artifactory
 ```
 
+Sample of using docker-promote on an artifact:
+
+```yaml
+steps:
+  - name: docker_promote_artifacts
+    image: target/vela-artifactory:v0.2.0
+    pull: true
+    parameters:
+      action: docker-promote
+      target_repo: libs-snapshot-local
+      docker_registry: octocat/hello-world
+      tag: latest
+      target_docker_registry: octocat/hello-world
+      target_tags: "${BUILD_COMMIT:0:8}"
+```
+
 ## Secrets
 
 {{% alert color="warning" %}}
@@ -165,6 +181,19 @@ The following parameters are used to configure the `delete` action:
 | Name        | Description                                          | Required | Default |
 | ----------- | ---------------------------------------------------- | -------- | ------- |
 | `recursive` | enables removing sub-directories for the artifact(s) | `false`  | `false` |
+
+### Docker-Promote
+
+The following parameters are used to configure the `docker-promote` action:
+
+| Name                     | Description                                           | Required | Default  |
+| ------------------------ | ----------------------------------------------------- | -------- | -------- |
+| `target_repo`            | name of the docker registry containing the image      | `true`   | `N/A`    |
+| `docker_registry`        | path to image in docker registry                      | `true`   | `N/A`    |
+| `target_docker_registry` | path for target image in docker registry              | `true`   | `N/A`    |
+| `tag`                    | name of the tag for promoting                         | `true`   | `N/A`    |
+| `target_tags`            | name of the final tags after promotion                | `true`   | `N/A`    |
+| `copy`                   | set to copy instead of moving the image               | `false`  | `false`  |
 
 #### Set-Prop
 


### PR DESCRIPTION
* Added missing information on the `docker-promote` action
* Upgraded the image for the plugin to `v0.2.0`

https://github.com/go-vela/vela-artifactory/releases/tag/v0.2.0