### PR TITLE
docs(template): remove coming soon wording

### DIFF
--- a/content/templates/_index.md
+++ b/content/templates/_index.md
@@ -8,5 +8,3 @@ menu:
   main:
     weight: 405
 ---
-
-COMING SOON!


### PR DESCRIPTION
The template content exists so no longer need the "coming soon" wording.