### PR TITLE
feat: add concept docs for worker routing

### DIFF
--- a/content/concepts/pipeline/worker/_index.md
+++ b/content/concepts/pipeline/worker/_index.md
@@ -7,7 +7,7 @@ description: >
 
 The `worker` component is a part of a [pipeline](/docs/concepts/pipeline/) for Vela.
 
-This declaration allows you to route you build to a subset of workers within a Vela cluster.
+This declaration allows you to route your build to a subset of workers within a Vela cluster.
 
 {{% alert color="info" %}}
 Routes can **only** be made by a system administrator. 
@@ -50,5 +50,5 @@ steps:
 ```
 
 {{% alert color="info" %}}
-This pipeline will start and run on a worker with the available queue `docker:large`
+This pipeline will start and run on a worker with the available route `docker:large`
 {{% /alert %}}

--- a/content/concepts/pipeline/worker/_index.md
+++ b/content/concepts/pipeline/worker/_index.md
@@ -1,0 +1,54 @@
+---
+title: "Worker"
+linkTitle: "Worker"
+description: >
+  This section contains information on the worker component for a pipeline.
+---
+
+The `worker` component is a part of a [pipeline](/docs/concepts/pipeline/) for Vela.
+
+This declaration allows you to route you build to a subset of workers within a Vela cluster.
+
+{{% alert color="info" %}}
+Routes can **only** be made by a system administrator. 
+{{% /alert %}}
+
+Routing can guarantee a build is ran on a specific platform or runtime within a cluster. This may be extremely useful when your building artifacts that can only be built on specific architectures.
+
+{{% alert color="warning" %}}
+It's import to remember that pinning yourself to workers lowers the number of available workers you can run on. 
+{{% /alert %}}
+
+## Fields
+
+The following fields are used to configure the component:
+
+| Name       | Description                                                     | Required |
+| ---------- | --------------------------------------------------------------- | -------- |
+| `platform` | run a build on a specific platform available within the cluster | `false`  |
+| `flavor`   | run a build on a flavor of workers within platform              | `false`  |
+
+## Syntax
+
+The following is an example of valid syntax for the component:
+
+```diff
+version: "1"
+
+metadata:
+  template: false
+
++worker:
++  platform: docker
++  flavor: large
+
+steps:
+  - name: test
+    image: golang
+    commands:
+      - go test ./...
+```
+
+{{% alert color="info" %}}
+This pipeline will start and run on a worker with the available queue `docker:large`
+{{% /alert %}}

--- a/content/concepts/pipeline/worker/flavor.md
+++ b/content/concepts/pipeline/worker/flavor.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the flavor component for a worker.
 ---
 
-The `flavor` component is a part of a [template](/docs/concepts/pipeline/templates/) for Vela.
+The `flavor` component is a part of a [template](/docs/concepts/pipeline/flavor/) for Vela.
 
 This declaration allows you to route your build to a single flavors within a Vela cluster.
 

--- a/content/concepts/pipeline/worker/flavor.md
+++ b/content/concepts/pipeline/worker/flavor.md
@@ -1,0 +1,34 @@
+---
+title: "Flavor"
+linkTitle: "Flavor"
+description: >
+  This section contains information on the flavor component for a worker.
+---
+
+The `flavor` component is a part of a [template](/docs/concepts/pipeline/templates/) for Vela.
+
+This declaration allows you to route your build to a single flavors within a Vela cluster.
+
+## Syntax
+
+The following is an example of valid syntax for the component:
+
+```diff
+version: "1"
+
+metadata:
+  template: false
+
+worker:
++  flavor: large
+
+steps:
+  - name: test
+    image: golang
+    commands:
+      - go test ./...
+```
+
+{{% alert color="info" %}}
+This pipeline will start and run on a worker with the available route `large`
+{{% /alert %}}

--- a/content/concepts/pipeline/worker/platform.md
+++ b/content/concepts/pipeline/worker/platform.md
@@ -1,0 +1,34 @@
+---
+title: "Platform"
+linkTitle: "Platform"
+description: >
+  This section contains information on the platform component for a worker.
+---
+
+The `platform` component is a part of a [template](/docs/concepts/pipeline/templates/) for Vela.
+
+This declaration allows you to route your build to a single platform within a Vela cluster.
+
+## Syntax
+
+The following is an example of valid syntax for the component:
+
+```diff
+version: "1"
+
+metadata:
+  template: false
+
+worker:
++  platform: docker
+
+steps:
+  - name: test
+    image: golang
+    commands:
+      - go test ./...
+```
+
+{{% alert color="info" %}}
+This pipeline will start and run on a worker with the available route `docker`
+{{% /alert %}}

--- a/content/concepts/pipeline/worker/platform.md
+++ b/content/concepts/pipeline/worker/platform.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the platform component for a worker.
 ---
 
-The `platform` component is a part of a [template](/docs/concepts/pipeline/templates/) for Vela.
+The `platform` component is a part of a [template](/docs/concepts/pipeline/platform/) for Vela.
 
 This declaration allows you to route your build to a single platform within a Vela cluster.
 


### PR DESCRIPTION
This PR showcases how a user would route a build to a worker.