### PR TITLE
feat: add docs for external secrets

### DIFF
--- a/content/concepts/pipeline/secrets/_index.md
+++ b/content/concepts/pipeline/secrets/_index.md
@@ -23,13 +23,13 @@ Any variable provided with this declaration will allow step(s) to request access
 
 The following fields are used to configure the component:
 
-| Name     | Description                                  | Required |
-| -------- | -------------------------------------------- | -------- |
-| `engine` | name of storage backend to fetch secret from | `false`  |
-| `key`    | path to secret to fetch from storage backend | `false`  |
-| `name`   | name of secret to reference in the pipeline  | `true`   |
-| `type`   | type of secret to fetch from storage backend | `false`  |
-| `type`   | loop up a secret via running a secret plugin | `false`  |
+| Name       | Description                                  | Required |
+| ---------- | -------------------------------------------- | -------- |
+| `engine`   | name of storage backend to fetch secret from | `false`  |
+| `key`      | path to secret to fetch from storage backend | `false`  |
+| `name`     | name of secret to reference in the pipeline  | `true`   |
+| `type`     | type of secret to fetch from storage backend | `false`  |
+| `origin`   | look up a secret via running a secret plugin | `false`  |
 
 {{% alert color="info" %}}
 The following fields have a default value already set:
@@ -37,7 +37,7 @@ The following fields have a default value already set:
 - `engine`: `native`
 - `key`: `<secret name>`
 - `type`: `repo`
-  {{% /alert %}}
+{{% /alert %}}
 
 ## Syntax
 

--- a/content/concepts/pipeline/secrets/_index.md
+++ b/content/concepts/pipeline/secrets/_index.md
@@ -29,6 +29,7 @@ The following fields are used to configure the component:
 | `key`    | path to secret to fetch from storage backend | `false`  |
 | `name`   | name of secret to reference in the pipeline  | `true`   |
 | `type`   | type of secret to fetch from storage backend | `false`  |
+| `type`   | loop up a secret via running a secret plugin | `false`  |
 
 {{% alert color="info" %}}
 The following fields have a default value already set:

--- a/content/concepts/pipeline/secrets/key.md
+++ b/content/concepts/pipeline/secrets/key.md
@@ -26,12 +26,12 @@ metadata:
 secrets:
   - name: username
     engine: native
-+   key: egithub/octocat/username
++   key: github/octocat/username
     type: repo
 
   - name: password
     engine: native
-+   key: egithub/octocat/password
++   key: github/octocat/password
     type: repo
 
 steps:

--- a/content/concepts/pipeline/secrets/origin.md
+++ b/content/concepts/pipeline/secrets/origin.md
@@ -1,0 +1,53 @@
+---
+title: "Origin"
+linkTitle: "Origin"
+description: >
+  This section contains information on the origin component for a secret.
+---
+
+The `origin` component is a part of a [secret](/docs/concepts/pipeline/secrets/) for Vela.
+
+This declaration allows you to pull secrets from non-internal secret providers via plugins.
+
+{{% alert color="info" %}}
+To see what plugins are supported and how they integrate with the Vela build lifecycle see the [plugins page](/docs/plugins/secrets/)
+{{% /alert %}}
+
+## Syntax
+
+The following is an example of valid syntax for the component:
+
+```diff
+version: "1"
+
+metadata:
+  template: false
+
+secrets:
+  # Implicit secret definition.
+  - name: vault_token
+
++  - origin:
++     name: vault external secrets
++     image: target/secret-vault
++     secrets: [ vault_token ]
++     parameters:
++       addr: vault.company.com
++       auth_method: token
++       username: octocat
++       items:
++         - source: secret/vela
++           path: user
+
+steps:
+  - name: test
+    image: golang
+    secrets: [ username, password ]
+    commands:
+      - cat /vela/secrets/user/name
+      - cat /vela/secrets/user/password
+```
+
+{{% alert color="info" %}}
+To see more information on the Vault plugin usage see the [Vault docs](docs/plugins/secret/registry/vault)
+{{% /alert %}}

--- a/content/plugins/overview.md
+++ b/content/plugins/overview.md
@@ -15,7 +15,7 @@ Before you begin your plugin journey we recommend the following pre-requisites:
 
 ## Pipeline
 
-These plugins are designed to be used within steps, stages and template pipelines. Pipeline plugins work via environment variables that pass data from pipeline to the container at runtime. 
+These plugins are designed to be used within steps, stages and template pipelines. Pipeline plugins configuration works via environment variables that pass data from pipeline to the container at runtime. 
 
 A pipeline plugin is a Docker container that is designed to perform a set of pre-defined actions.
 
@@ -28,4 +28,83 @@ These actions can be for any number of general tasks, including:
 
 ## Secret
 
-Coming Soon!
+{{% alert title="Note:" color="primary" %}}
+Secret plugins are by default under an allow list of available images for an installation. To know which secret plugins are available for your Vela installation we recommend consulting your system administrators. 
+{{% /alert %}}
+
+These plugins are designed to be used within the secrets Yaml block of pipelines. Secret plugins configuration works via environment variables that pass data from pipeline to the container at runtime. 
+
+A secret plugin works in tandem with the Vela workspace to read data from a provider and write them into an available location (`/vela/secrets`) within a pipeline.
+
+## Using a plugin
+
+Typically, plugins are configured as a step in a pipeline and should accept their configuration via environment variables. The below example shows a pipeline and secret plugin working together to publish an image to a registry:
+
+```yaml
+version: "1"
+
+steps:
+  - name: plugin
+    image: target/vela-docker
+    pull: true
+    parameters:
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
+
+secrets:
+  - name: vault_token
+
+  - origin:
+      name: plugin
+      image: target/secret-vault
+      pull: true
+      secrets: [ vault_token ]
+      parameters:
+        addr: vault.company.com
+        auth_method: token
+        items:
+          - source: secret/docker
+            path: docker   
+```
+
+We pass these variables in Vela using the `parameters` block. Any variable passed to this block, will be injected into the step as `PARAMETER_<variable>`:
+
+```diff
+version: "1"
+
+steps:
+  - name: docker
+    image: target/vela-docker
+    pull: true
++   parameters:
++     registry: index.docker.io
++     repo: index.docker.io/octocat/hello-world
+
+secrets:
+  - name: vault_token
+
+  - origin:
+      name: vault
+      image: target/secret-vault
+      pull: true
+      secrets: [ vault_token ]
++     parameters:
++       addr: vault.company.com
++       auth_method: token
++       items:
++         - source: secret/docker
++           path: docker  
+```
+
+From the above example, the following environment variables would be added to the containers:
+
+**Docker:**
+
+* `PARAMETER_REGISTRY=index.docker.io`
+* `PARAMETER_REPO=index.docker.io/octocat/hello-world`
+
+**Vault:**
+
+* `PARAMETER_ADDR=index.docker.io`
+* `PARAMETER_AUTH_METHOD=index.docker.io/octocat/hello-world`
+* `PARAMETER_ITEMS={"items": [{"source": "secret/docker"}],"path": "docker"}`

--- a/content/plugins/pipeline/_index.md
+++ b/content/plugins/pipeline/_index.md
@@ -4,40 +4,22 @@ linkTitle: "Pipeline"
 description: >
   Learn about pipeline plugins for Vela.
 ---
-## Using a plugin
 
-Typically, plugins are configured as a step in a pipeline and should accept their configuration via environment variables. The below example shows a Docker plugin that can publish an image to a registry:
+## Under the hood
 
-```yaml
-version: "1"
-
-steps:
-  - name: plugin
-    image: target/vela-docker:v0.1.0
-    pull: true
-    parameters:
-      registry: index.docker.io
-      repo: index.docker.io/octocat/hello-world
-```
-
-We pass these variables in Vela using the `parameters` block. Any variable passed to this block, will be injected into the step as `PARAMETER_<variable>`:
+Pipeline plugins are designed to automate, customize, and execute your software development workflows. The example we have shown is publishing an image to a registry:
 
 ```diff
 version: "1"
 
 steps:
-  - name: plugin
-    image: target/vela-docker:v0.1.0
+  - name: docker
+    image: target/vela-docker
     pull: true
 +   parameters:
 +     registry: index.docker.io
 +     repo: index.docker.io/octocat/hello-world
 ```
-
-From the above example, the following environment variables would be added to the container:
-
-* `PARAMETER_REGISTRY=index.docker.io`
-* `PARAMETER_REPO=index.docker.io/octocat/hello-world`
 
 ## Building a plugin
 

--- a/content/plugins/pipeline/registry/artifactory.md
+++ b/content/plugins/pipeline/registry/artifactory.md
@@ -183,7 +183,7 @@ steps:
 ```
 
 {{% alert color="info" %}}
-This example will read the secrets values in the files stored at `/vela/secrets/`:
+This example will read the secrets values in the volume stored at `/vela/secrets/`:
 {{% /alert %}}
 
 ## Parameters

--- a/content/plugins/pipeline/registry/artifactory.md
+++ b/content/plugins/pipeline/registry/artifactory.md
@@ -10,6 +10,12 @@ Source Code: https://github.com/go-vela/vela-artifactory
 
 Registry: https://hub.docker.com/r/target/vela-artifactory
 
+{{% alert color="tip" %}}
+This plugin supports environment (`PARAMETER_*`) and volume (`/vela/parameters/*`) configuration for setting parameters.
+
+The precedence order is take files then environment variables if both are set in a container.
+{{% /alert %}}
+
 ## Usage
 
 Sample of copying an artifact:
@@ -116,6 +122,8 @@ steps:
 Users should refrain from configuring sensitive information in their pipeline in plain text.
 {{% /alert %}}
 
+### Internal
+
 The plugin accepts the following `parameters` for authentication:
 
 | Parameter   | Environment Variable Configuration                              |
@@ -146,6 +154,36 @@ This example will add the `secrets` to the `copy_artifacts` step as environment 
 
 - `ARTIFACTORY_USERNAME`=<value>
 - `ARTIFACTORY_PASSWORD`=<value>
+{{% /alert %}}
+
+### External
+
+The plugin accepts the following files for authentication:
+
+| Parameter   | Volume Configuration                           |
+| ----------- | ------------------------------------------------------------ |
+| `api_key`  | `/vela/parameters/config/artifactory/api_key`, `/vela/secrets/artifactory/api_key` |
+| `password`  | `/vela/parameters/config/artifactory/password`, `/vela/secrets/artifactory/password` |
+| `username`  | `/vela/parameters/config/artifactory/username`, `/vela/secrets/artifactory/username` |
+
+Users can use [Vela external secrets](/docs/concepts/pipeline/secrets/) to substitute these sensitive values at runtime:
+
+```diff
+steps:
+  - name: copy_artifacts
+    image: target/vela-artifactory:v0.2.0
+    pull: true
+    parameters:
+      action: copy
+      path: libs-snapshot-local/foo.txt
+      target: libs-snapshot-local/bar.txt
+      url: http://localhost:8081/artifactory
+-     username: octocat
+-     password: superSecretPassword
+```
+
+{{% alert color="info" %}}
+This example will read the secrets values in the files stored at `/vela/secrets/`:
 {{% /alert %}}
 
 ## Parameters

--- a/content/plugins/pipeline/registry/docker.md
+++ b/content/plugins/pipeline/registry/docker.md
@@ -10,6 +10,12 @@ Source Code: https://github.com/go-vela/vela-docker
 
 Registry: https://hub.docker.com/r/target/vela-docker
 
+{{% alert color="tip" %}}
+This plugin supports environment (`PARAMETER_*`) and volume (`/vela/parameters/*`) configuration for setting parameters.
+
+The precedence order is take files then environment variables if both are set in a container.
+{{% /alert %}}
+
 ## Usage
 
 Sample of building and publishing an image:
@@ -114,6 +120,8 @@ steps:
 Users should refrain from configuring sensitive information in their pipeline in plain text.
 {{% /alert %}}
 
+### Internal
+
 The plugin accepts the following `parameters` for authentication:
 
 | Parameter   | Environment Variable Configuration                           |
@@ -141,6 +149,33 @@ This example will add the `secrets` to the `publish_hello-world` step as environ
 
 - `DOCKER_USERNAME`=<value>
 - `DOCKER_PASSWORD`=<value>
+{{% /alert %}}
+
+### External
+
+The plugin accepts the following files for authentication:
+
+| Parameter   | Volume Configuration                           |
+| ----------- | ------------------------------------------------------------ |
+| `password`  | `/vela/parameters/docker/registry/password`, `/vela/secrets/docker/registry/password`, `/vela/secrets/docker/password` |
+| `username`  | `/vela/parameters/docker/registry/username`, `/vela/secrets/docker/registry/username`, `/vela/secrets/docker/username` |
+
+Users can use [Vela external secrets](/docs/concepts/pipeline/secrets/) to substitute these sensitive values at runtime:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-docker:v0.2.1
+    pull: true
+    parameters:
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
+-     username: octocat
+-     password: superSecretPassword
+```
+
+{{% alert color="info" %}}
+This example will read the secrets values in the files stored at `/vela/secrets/`:
 {{% /alert %}}
 
 ## Parameters

--- a/content/plugins/pipeline/registry/docker.md
+++ b/content/plugins/pipeline/registry/docker.md
@@ -175,7 +175,7 @@ steps:
 ```
 
 {{% alert color="info" %}}
-This example will read the secrets values in the files stored at `/vela/secrets/`:
+This example will read the secrets values in the volume stored at `/vela/secrets/`:
 {{% /alert %}}
 
 ## Parameters

--- a/content/plugins/pipeline/registry/downstream.md
+++ b/content/plugins/pipeline/registry/downstream.md
@@ -134,7 +134,7 @@ steps:
 ```
 
 {{% alert color="info" %}}
-This example will read the secrets values in the files stored at `/vela/secrets/`:
+This example will read the secrets values in the volume stored at `/vela/secrets/`:
 {{% /alert %}}
 
 ## Parameters

--- a/content/plugins/pipeline/registry/downstream.md
+++ b/content/plugins/pipeline/registry/downstream.md
@@ -10,6 +10,12 @@ Source Code: https://github.com/go-vela/vela-downstream
 
 Registry: https://hub.docker.com/r/target/vela-downstream
 
+{{% alert color="tip" %}}
+This plugin supports environment (`PARAMETER_*`) and volume (`/vela/parameters/*`) configuration for setting parameters.
+
+The precedence order is take files then environment variables if both are set in a container.
+{{% /alert %}}
+
 ## Usage
 
 {{% alert color="warning" %}}
@@ -74,6 +80,8 @@ steps:
 Users should refrain from configuring sensitive information in their pipeline in plain text.
 {{% /alert %}}
 
+### Internal
+
 The plugin accepts the following `parameters` for authentication:
 
 | Parameter | Environment Variable Configuration                                  |
@@ -100,6 +108,33 @@ steps:
 This example will add the `secrets` to the `trigger_hello-world` step as environment variables:
 
 - `DOWNSTREAM_TOKEN`=<value>
+{{% /alert %}}
+
+### External
+
+The plugin accepts the following files for authentication:
+
+| Parameter | Volume Configuration                                                                |
+| --------- | ----------------------------------------------------------------------------------- |
+| `token`   | `/vela/parameters/downstream/config/token`, `/vela/secrets/downstream/config/token` |
+
+Users can use [Vela external secrets](/docs/concepts/pipeline/secrets/) to substitute these sensitive values at runtime:
+
+```diff
+steps:
+  - name: trigger_hello-world
+    image: target/vela-downstream:v0.2.0
+    pull: true
+    parameters:
+      branch: master
+      repos:
+        - octocat/hello-world
+      server: https://vela-server.localhost
+-     token: superSecretVelaToken
+```
+
+{{% alert color="info" %}}
+This example will read the secrets values in the files stored at `/vela/secrets/`:
 {{% /alert %}}
 
 ## Parameters

--- a/content/plugins/pipeline/registry/git.md
+++ b/content/plugins/pipeline/registry/git.md
@@ -14,6 +14,12 @@ Source Code: https://github.com/go-vela/vela-git
 
 Registry: https://hub.docker.com/r/target/vela-git
 
+{{% alert color="tip" %}}
+This plugin supports environment (`PARAMETER_*`) and volume (`/vela/parameters/*`) configuration for setting parameters.
+
+The precedence order is take files then environment variables if both are set in a container.
+{{% /alert %}}
+
 ## Usage
 
 {{% alert color="info" %}}
@@ -70,6 +76,8 @@ steps:
 Users should refrain from configuring sensitive information in their pipeline in plain text.
 {{% /alert %}}
 
+### Internal
+
 The plugin accepts the following `parameters` for authentication:
 
 | Parameter        | Environment Variable Configuration                                |
@@ -99,6 +107,35 @@ This example will add the `secrets` to the `clone_hello-world` step as environme
 
 - `GIT_USERNAME`=<value>
 - `GIT_PASSWORD`=<value>
+{{% /alert %}}
+
+### External
+
+The plugin accepts the following files for authentication:
+
+| Parameter        | Volume Configuration                                                      |
+| ---------------- | ------------------------------------------------------------------------- |
+| `netrc_password` | `/vela/parameters/git/netrc/password`, `/vela/secrets/git/netrc/password` |
+| `netrc_username` | `/vela/parameters/git/netrc/username`, `/vela/secrets/git/netrc/username` |
+
+Users can use [Vela external secrets](/docs/concepts/pipeline/secrets/) to substitute these sensitive values at runtime:
+
+```diff
+steps:
+  - name: clone_hello-world
+    image: target/vela-git:v0.3.0
+    pull: true
+    parameters:
+-     netrc_username: octocat
+-     netrc_password: superSecretPassword
+      path: /home/octocat_hello-world_1
+      ref: refs/heads/master
+      remote: https://github.com/octocat/hello-world.git
+      sha: 7fd1a60b01f91b314f59955a4e4d4e80d8edf11d
+```
+
+{{% alert color="info" %}}
+This example will read the secrets values in the files stored at `/vela/secrets/`:
 {{% /alert %}}
 
 ## Parameters

--- a/content/plugins/pipeline/registry/git.md
+++ b/content/plugins/pipeline/registry/git.md
@@ -135,7 +135,7 @@ steps:
 ```
 
 {{% alert color="info" %}}
-This example will read the secrets values in the files stored at `/vela/secrets/`:
+This example will read the secrets values in the volume stored at `/vela/secrets/`:
 {{% /alert %}}
 
 ## Parameters

--- a/content/plugins/pipeline/registry/kubernetes.md
+++ b/content/plugins/pipeline/registry/kubernetes.md
@@ -148,7 +148,7 @@ steps:
 ```
 
 {{% alert color="info" %}}
-This example will read the secrets values in the files stored at `/vela/secrets/`:
+This example will read the secrets values in the volume stored at `/vela/secrets/`:
 {{% /alert %}}
 
 ## Parameters

--- a/content/plugins/pipeline/registry/kubernetes.md
+++ b/content/plugins/pipeline/registry/kubernetes.md
@@ -10,6 +10,12 @@ Source Code: https://github.com/go-vela/vela-kubernetes
 
 Registry: https://hub.docker.com/r/target/vela-kubernetes
 
+{{% alert color="tip" %}}
+This plugin supports environment (`PARAMETER_*`) and volume (`/vela/parameters/*`) configuration for setting parameters.
+
+The precedence order is take files then environment variables if both are set in a container.
+{{% /alert %}}
+
 ## Usage
 
 Sample of applying Kubernetes files:
@@ -86,6 +92,8 @@ steps:
 Users should refrain from configuring sensitive information in their pipeline in plain text.
 {{% /alert %}}
 
+### Internal
+
 The plugin accepts the following `parameters` for authentication:
 
 | Parameter | Environment Variable Configuration               |
@@ -113,6 +121,34 @@ steps:
 This example will add the `secrets` to the `kubernetes` step as environment variables:
 
 - `KUBE_CONFIG`=<value>
+{{% /alert %}}
+
+### External
+
+The plugin accepts the following files for authentication:
+
+| Parameter        | Volume Configuration                                                       |
+| ---------------- | -------------------------------------------------------------------------- |
+| `config`  | `/vela/parameters/kubernetes/config/file`, `/vela/secrets/kubernetes/config/file` |
+
+Users can use [Vela external secrets](/docs/concepts/pipeline/secrets/) to substitute these sensitive values at runtime:
+
+```diff
+steps:
+  - name: kubernetes
+    image: target/vela-kubernetes:v0.1.0
+    pull: true
+    parameters:
+      action: apply
+      files: [ kubernetes/common, kubernetes/dev/deploy.yml ]
+-     config: |
+-     ---
+-     apiVersion: v1
+-     kind: Config
+```
+
+{{% alert color="info" %}}
+This example will read the secrets values in the files stored at `/vela/secrets/`:
 {{% /alert %}}
 
 ## Parameters

--- a/content/plugins/pipeline/registry/s3_cache.md
+++ b/content/plugins/pipeline/registry/s3_cache.md
@@ -10,6 +10,12 @@ Source Code: https://github.com/go-vela/vela-s3-cache
 
 Registry: https://hub.docker.com/r/target/vela-s3-cache
 
+{{% alert color="tip" %}}
+This plugin supports environment (`PARAMETER_*`) and volume (`/vela/parameters/*`) configuration for setting parameters.
+
+The precedence order is take files then environment variables if both are set in a container.
+{{% /alert %}}
+
 ## Usage
 
 Sample of restoring a cache:
@@ -59,6 +65,8 @@ steps:
 Users should refrain from configuring sensitive information in their pipeline in plain text.
 {{% /alert %}}
 
+### Internal
+
 The plugin accepts the following `parameters` for authentication:
 
 | Parameter       | Environment Variable Configuration                                       |
@@ -88,6 +96,35 @@ This example will add the `secrets` to the `restore_cache` step as environment v
 
 - `CACHE_S3_ACCESS_KEY`=<value>
 - `CACHE_S3_SECRET_KEY`=<value>
+{{% /alert %}}
+
+### External
+
+The plugin accepts the following files for authentication:
+
+| Parameter       | Volume Configuration                                                       |
+| --------------- | ------------------------------------------------------------------------ |
+| `access_key`    | `/vela/parameters/s3_cache/config/access_key`, `/vela/secrets/s3_cache/config/access_key`       |
+| `secret_key`    | `/vela/parameters/s3_cache/config/secret_key`, `/vela/secrets/s3_cache/config/secret_key`   |
+| `session_token` | `/vela/parameters/s3_cache/config/session_token`, `/vela/secrets/s3_cache/config/session_token` |
+
+Users can use [Vela external secrets](/docs/concepts/pipeline/secrets/) to substitute these sensitive values at runtime:
+
+```diff
+steps:
+  - name: restore_cache
+    image: target/vela-s3-cache:v0.2.0
+    pull: true
+    parameters:
+      action: restore
+      root: mybucket
+      server: mybucket.s3-us-west-2.amazonaws.com
+-     access_key: AKIAIOSFODNN7EXAMPLE
+-     secret_key: 123456789QWERTYEXAMPLE
+```
+
+{{% alert color="info" %}}
+This example will read the secrets values in the files stored at `/vela/secrets/`:
 {{% /alert %}}
 
 ## Parameters

--- a/content/plugins/pipeline/registry/s3_cache.md
+++ b/content/plugins/pipeline/registry/s3_cache.md
@@ -124,7 +124,7 @@ steps:
 ```
 
 {{% alert color="info" %}}
-This example will read the secrets values in the files stored at `/vela/secrets/`:
+This example will read the secrets values in the volume stored at `/vela/secrets/`:
 {{% /alert %}}
 
 ## Parameters

--- a/content/plugins/pipeline/registry/terraform.md
+++ b/content/plugins/pipeline/registry/terraform.md
@@ -6,6 +6,12 @@ Source Code: https://github.com/go-vela/vela-terraform
 
 Registry: https://hub.docker.com/r/target/vela-terraform
 
+{{% alert color="tip" %}}
+This plugin supports environment (`PARAMETER_*`) and volume (`/vela/parameters/*`) configuration for setting parameters.
+
+The precedence order is take files then environment variables if both are set in a container.
+{{% /alert %}}
+
 ## Usage
 
 {{% alert color="note" %}}

--- a/content/plugins/secret/_index.md
+++ b/content/plugins/secret/_index.md
@@ -5,4 +5,40 @@ description: >
   Learn about secret plugins for Vela.
 ---
 
-Coming soon!
+## Under the hood
+
+Secret plugins are designed to be used to read secrets in volumes within the Vela workspace. When a secret plugin runs the plugin should write data to the custom Vela mount (`/vela/secrets/`) as key/value pairs. 
+
+```diff
+secrets:
+  - name: vault_token
+
+  - origin:
+      name: vault
+      image: target/secret-vault
+      pull: true
+      secrets: [ vault_token ]
++     parameters:
++       addr: vault.company.com
++       auth_method: token
++       username: octocat
++       items:
++         - source: secret/docker
++           path: docker  
+```
+
+From the above example, will have written the following available secrets to:
+
+* `/vela/secrets/docker/<key>/<value/`
+
+## Building a plugin
+
+The reason we use the environment for configuration is because it allows plugins to be written in any language! We have a number of tutorials that can help you get started in writing a plugin in your preferred language.
+
+Before you get started writing a plugin you should have a good understanding of how Docker images are built. This will allow you to build a optimal plugin that follows [Docker's best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/).
+
+{{% alert color="tip" %}}
+We recommend that all plugins be placed inside a [scratch image](https://hub.docker.com/_/scratch).
+{{% /alert %}}
+
+**All** secret plugins should write secret data to the `/vela/secrets/` workspace. This ensures that secrets read into the pipeline are compatible with pipeline plugins.

--- a/content/plugins/secret/registry/vault.md
+++ b/content/plugins/secret/registry/vault.md
@@ -1,0 +1,129 @@
+---
+title: "Vault"
+linkTitle: "Vault"
+description: >
+  Learn about the Vault secret plugin.
+---
+
+## Overview
+
+This plugin enables the ability pull secrets from [Vault](https://www.vaultproject.io/) into the secret mount within a Vela pipeline.
+
+Source Code: https://github.com/go-vela/secret-vault
+
+Registry: https://hub.docker.com/r/target/secret-vault
+
+## Usage
+
+Sample of writing a secret using token authentication:
+
+```yaml
+secrets:
+  - origin:
+      name: vault
+      image: target/vela/secret-vault:latest
+      parameters:
+        addr: vault.company.com
+        token: superSecretVaultToken
+        auth_method: token
+        items:
+          # Written to path: "/vela/secrets/docker/<key>"
+          - source: secret/vela/username
+            path: docker
+```
+
+Sample of reading a secret using ldap authentication:
+
+```diff
+secrets:
+  - origin:
+      name: vault
+      image: target/vela/secret-vault:latest
+      parameters:
+        addr: vault.company.com
++       username: octocat
++       password: superSecretPassword
+-       token: superSecretVaultToken
++       auth_method: ldap
+        items:
+          # Written to path: "/vela/secrets/docker/<key>"
+          - source: secret/vela/username
+            path: docker
+```
+
+Sample of reading a secret using ldap authentication with verbose logging:
+
+```diff
+secrets:
+  - origin:
+      name: vault
+      image: target/vela/secret-vault:latest
+      parameters:
+        addr: vault.company.com
+        username: octocat
+        password: superSecretPassword
+        token: superSecretVaultToken
+        auth_method: ldap
++       log_level: trace        
+        items:
+          # Written to path: "/vela/secrets/docker/<key>"
+          - source: secret/vela/username
+            path: docker
+```
+
+## Secrets
+
+**NOTE: Users should refrain from configuring sensitive information in your pipeline in plain text.**
+
+**NOTE: Secrets used within the secret plugin must exist as Vela secrets.**
+
+You can use Vela secrets to substitute sensitive values at runtime:
+
+```diff
+secrets:
+  # Repo secret created within Vela
+  - name: vault_token
+  
+  # Example using token authentication method
+  - origin:
+      name: vault
+      image: target/vela/secret-vault:latest
+      secret: [ vault_token ]
+      parameters:
+        addr: vault.company.com
+-       token: superSecretVaultToken
+        auth_method: token
+        items:
+          # Written to path: "/vela/secrets/docker/<key>"
+          - source: secret/vela/username
+            path: docker
+```
+
+## Parameters
+
+The following parameters are used to configure the image:
+
+| Name          | Description                                              | Required  | Default |
+| ------------- | -------------------------------------------------------- | --------- | ------- |
+| `addr`        | address to the instance                                  | `true`    | `N/A`   |
+| `auth_method` | authentication method for interfacing (i.e. token, ldap) | `true`    | `N/A`   |
+| `log_level`   | set the log level for the plugin                         | `true`    | `info`  |
+| `password`    | password for server authentication with ldap             | `false`   | `N/A`   |
+| `token`       | token for server authentication                          | `false`   | `N/A`   |
+| `username`    | set the log level for the plugin                         | `false`   | `N/A`   |
+
+#### Read
+
+The following parameters are used to configure reading:
+
+| Name    | Description                                      | Required | Default |
+| ------- | ------------------------------------------------ | -------- | ------- |
+| `items` | enables pretending to perform the apply          | `true`  | `false` |
+
+## Template
+
+COMING SOON!
+
+## Troubleshooting
+
+Below are a list of common problems and how to solve them:

--- a/content/usage/getting-started/workspace.md
+++ b/content/usage/getting-started/workspace.md
@@ -6,17 +6,13 @@ description: >
   Shared directory that all build steps begin at.
 ---
 
-## Cloning
-
-Vela automatically checks out the repository into a local volume that is mounted into each Docker container. This volume is generally referred to as a workspace, which defines the working directory shared by all steps in a build.
-
-```sh
-git clone https://github.com/go-vela/hello-world.git <workspace>
-```
+Vela uses a shared volume model between steps to allow shared file system during the build process. These volumes should be considered ephemeral in the sense once a build completes execution all data via the volume being destroyed. 
 
 ## Working Directory
 
-This ensures the code, dependencies, and compiled binaries are persisted and shared between the steps. The default workspace attached to every build is unique and matches the below pattern:
+This ensures the configuration, code, dependencies, and compiled binaries are persisted and shared between the steps. The default workspace attached to every build is unique and matches the below pattern:
+
+**Source:**
 
 ```sh
 # Syntax
@@ -26,10 +22,46 @@ This ensures the code, dependencies, and compiled binaries are persisted and sha
 /vela/src/github.com/go-vela/hello-world
 ```
 
+**Secrets:**
+
+```sh
+# Syntax
+/vela/secrets/<path>/<key>
+
+# Example
+/vela/secrets/github/username/
+/vela/secrets/github/password/
+```
+
+**Parameters:**
+
+```sh
+# Syntax
+/vela/secrets/<path>/<key>
+
+# Example
+/vela/parameters/github/repo/settings/topics
+```
+
+{{% alert color="warning" %}}
+Before you use the parameters volume check the plugin authors docs to ensure it has support to read from `/vela/parameters`
+{{% /alert %}}
+
 This would be the equivalent to the following Docker commands being executed:
 
 ```sh
 docker volume create build-workspace
 
-docker run --volume=build-workspace:/vela/src/github.com/go-vela/hello-world <image>
+docker run --volume=build-workspace:/vela/ <image>
 ```
+
+## Cloning
+
+Vela automatically checks out the repository into a local volume that is mounted into each Docker container. This volume is generally referred to as a workspace, which defines the working directory shared by all steps in a build.
+
+```sh
+git clone https://github.com/go-vela/hello-world.git <workspace>
+```
+{{% alert color="warning" %}}
+In cases where your clone needs special configuration you should add a step at the beginning of the pipeline adding the desired behavior.
+{{% /alert %}}

--- a/content/usage/samples/secrets_external.md
+++ b/content/usage/samples/secrets_external.md
@@ -1,0 +1,127 @@
+---
+title: "External Secrets"
+toc: true
+weight: 1
+description: >
+  Sample pipeline with external secrets
+---
+
+Sample [Yaml](https://yaml.org/spec/) configuration for a project requiring a secrets to be used within a step
+
+## Scenario
+
+User is looking to create a pipeline that can integrate with a private Vault to inject secrets that can not be used with pushing Docker image to a registry.
+
+{{% alert title="Note:" color="primary" %}}
+It is assumed you have created secret `vault_token` in the web interface or [CLI](/docs/cli/).
+{{% /alert %}}
+
+The samples show a pipeline using repository secrets. Vela contains three secret types repository, organization, and shared. For examples on organization and shared please see the [secret concepts](/docs/concepts/pipeline/steps/secrets/) documentation.
+
+### Steps
+
+The following [pipeline concepts](/docs/concepts/pipeline) are being used in the pipeline below:
+
+* [Steps](/docs/concepts/pipeline/steps/)
+  * [Image](/docs/concepts/pipeline/steps/image/)
+  * [Pull](/docs/concepts/pipeline/steps/pull/)* 
+  * [Secrets](/docs/concepts/pipeline/steps/secrets/)
+  * [Parameters](/docs/concepts/pipeline/steps/parameters/)
+* [Secrets](/docs/concepts/pipeline/secrets/)
+
+The following [Vela plugins](/docs/concepts/pipeline) are being used in the pipeline below:
+
+* [Docker](/docs/plugins/pipeline/registry/docker/)
+
+{{% alert title="Note:" color="primary" %}}
+Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`
+
+It is recommended to pin `image:` versions for production pipelines
+{{% /alert %}}
+
+```yaml
+version: "1"
+
+steps:
+  - name: publish hello world
+    image: target/vela-docker
+    pull: true
+    parameters:
+      registry: index.docker.io
+      repo: index.docker.io/vela/hello-world
+
+
+secrets:
+  # Implicit secret definition.
+  - name: vault_token
+
+  - origin:
+      name: private vault
+      image: target/secret-vault
+      pull: true
+      secrets: [ vault_token ]
+      parameters:
+        addr: vault.company.com
+        auth_method: token
+        username: octocat
+        items:
+          - source: secret/docker
+            path: docker  
+```
+
+### Stages
+
+The following [pipeline concepts](/docs/concepts/pipeline) are being used in the pipeline below:
+
+* [Stages](/docs/concepts/pipeline/steps/)
+  * [Steps](/docs/concepts/pipeline/steps/)
+  * [Image](/docs/concepts/pipeline/steps/image/)
+  * [Pull](/docs/concepts/pipeline/steps/pull/)
+  * [Secrets](/docs/concepts/pipeline/steps/secrets/)
+  * [Parameters](/docs/concepts/pipeline/steps/parameters/)
+* [Secrets](/docs/concepts/pipeline/secrets/)
+
+The following [Vela plugins](/docs/concepts/pipeline) are being used in the pipeline below:
+
+* [Docker](/docs/plugins/pipeline/registry/docker/)
+
+{{% alert title="Note:" color="primary" %}}
+Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`
+
+It is recommended to pin `image:` versions for production pipelines
+{{% /alert %}}
+
+```yaml
+version: "1"
+
+worker:
+  runtime: docker
+
+stages:
+  docker:
+    steps:
+      - name: publish hello world
+        image: target/vela-docker
+        pull: true
+        secrets: [ docker_username, docker_password ]
+        parameters:
+          registry: index.docker.io
+          repo: index.docker.io/vela/hello-world
+
+secrets:
+  # Implicit secret definition.
+  - name: vault_token
+
+  - origin:
+      name: private vault
+      image: target/secret-vault
+      pull: true
+      secrets: [ vault_token ]
+      parameters:
+        addr: vault.company.com
+        auth_method: token
+        username: octocat
+        items:
+          - source: secret/docker
+            path: docker  
+```

--- a/content/usage/samples/secrets_external.md
+++ b/content/usage/samples/secrets_external.md
@@ -10,13 +10,13 @@ Sample [Yaml](https://yaml.org/spec/) configuration for a project requiring a se
 
 ## Scenario
 
-User is looking to create a pipeline that can integrate with a private Vault to inject secrets that can not be used with pushing Docker image to a registry.
+User is looking to create a pipeline that can integrate with a private Vault to inject secrets that can not be used with pushing a Docker image to a registry.
 
 {{% alert title="Note:" color="primary" %}}
 It is assumed you have created secret `vault_token` in the web interface or [CLI](/docs/cli/).
 {{% /alert %}}
 
-The samples show a pipeline using repository secrets. Vela contains three secret types repository, organization, and shared. For examples on organization and shared please see the [secret concepts](/docs/concepts/pipeline/steps/secrets/) documentation.
+The samples show a pipeline using repository secrets. Vela contains three secret types: repository, organization, and shared. For examples on organization and shared, please see the [secret concepts](/docs/concepts/pipeline/steps/secrets/) documentation.
 
 ### Steps
 
@@ -24,7 +24,7 @@ The following [pipeline concepts](/docs/concepts/pipeline) are being used in the
 
 * [Steps](/docs/concepts/pipeline/steps/)
   * [Image](/docs/concepts/pipeline/steps/image/)
-  * [Pull](/docs/concepts/pipeline/steps/pull/)* 
+  * [Pull](/docs/concepts/pipeline/steps/pull/)
   * [Secrets](/docs/concepts/pipeline/steps/secrets/)
   * [Parameters](/docs/concepts/pipeline/steps/parameters/)
 * [Secrets](/docs/concepts/pipeline/secrets/)
@@ -61,7 +61,7 @@ secrets:
       pull: true
       secrets: [ vault_token ]
       parameters:
-        addr: vault.company.com
+        addr: vault.example.com
         auth_method: token
         username: octocat
         items:
@@ -118,7 +118,7 @@ secrets:
       pull: true
       secrets: [ vault_token ]
       parameters:
-        addr: vault.company.com
+        addr: vault.example.com
         auth_method: token
         username: octocat
         items:

--- a/content/usage/samples/secrets_external.md
+++ b/content/usage/samples/secrets_external.md
@@ -44,7 +44,7 @@ version: "1"
 
 steps:
   - name: publish hello world
-    image: target/vela-docker
+    image: target/vela-docker:latest
     pull: true
     parameters:
       registry: index.docker.io
@@ -57,7 +57,7 @@ secrets:
 
   - origin:
       name: private vault
-      image: target/secret-vault
+      image: target/secret-vault:latest
       pull: true
       secrets: [ vault_token ]
       parameters:
@@ -101,7 +101,7 @@ stages:
   docker:
     steps:
       - name: publish hello world
-        image: target/vela-docker
+        image: target/vela-docker:latest
         pull: true
         secrets: [ docker_username, docker_password ]
         parameters:
@@ -114,7 +114,7 @@ secrets:
 
   - origin:
       name: private vault
-      image: target/secret-vault
+      image: target/secret-vault:latest
       pull: true
       secrets: [ vault_token ]
       parameters:

--- a/content/usage/samples/secrets_internal.md
+++ b/content/usage/samples/secrets_internal.md
@@ -44,7 +44,7 @@ version: "1"
 
 steps:
   - name: publish hello world
-    image: target/vela-docker:v0.2.1
+    image: target/vela-docker:latest
     pull: true
     secrets: [ docker_username, docker_password ]
     parameters:
@@ -95,7 +95,7 @@ stages:
   docker:
     steps:
       - name: publish hello world
-        image: target/vela-docker:v0.2.1
+        image: target/vela-docker:latest
         pull: true
         secrets: [ docker_username, docker_password ]
         parameters:

--- a/content/usage/samples/secrets_internal.md
+++ b/content/usage/samples/secrets_internal.md
@@ -16,7 +16,7 @@ User is looking to create a pipeline that can inject configuration that can not 
 It is assumed you have created secrets `docker_username` and `docker_password` in the web interface or [CLI](/docs/cli/).
 {{% /alert %}}
 
-The samples show a pipeline using repository secrets. Vela contains three secret types repository, organization, and shared. For examples on organization and shared please see the [secret concepts](/docs/concepts/pipeline/steps/secrets/) documentation.
+The samples show a pipeline using repository secrets. Vela contains three secret types: repository, organization, and shared. For examples on organization and shared, please see the [secret concepts](/docs/concepts/pipeline/steps/secrets/) documentation.
 
 ### Steps
 
@@ -24,7 +24,7 @@ The following [pipeline concepts](/docs/concepts/pipeline) are being used in the
 
 * [Steps](/docs/concepts/pipeline/steps/)
   * [Image](/docs/concepts/pipeline/steps/image/)
-  * [Pull](/docs/concepts/pipeline/steps/pull/)* 
+  * [Pull](/docs/concepts/pipeline/steps/pull/) 
   * [Secrets](/docs/concepts/pipeline/steps/secrets/)
   * [Parameters](/docs/concepts/pipeline/steps/parameters/)
 * [Secrets](/docs/concepts/pipeline/secrets/)


### PR DESCRIPTION
This PR adds the new secret documentation for release v0.6.0.

Content updates:

* Added sample in usage showing how to use them
* Added yaml tag documentation in concepts
* Updated plugin section to reflect pipeline and secret plugin types