### PR TITLE
enhancement: update how to build docker images

### DIFF
--- a/content/plugins/pipeline/registry/docker.md
+++ b/content/plugins/pipeline/registry/docker.md
@@ -5,7 +5,7 @@ title: "Docker"
 ## Overview
 
 {{% alert color="warning" %}}
-This plugin was originally used to build **all** Docker images. The functionality of this plugin still exists within [Kaniko](/kaniko)
+This plugin was originally used to build **all** Docker images. The functionality of this plugin still exists within [Kaniko](/docs/plugins/pipeline/registry/kaniko)
 {{% /alert %}}
 
 This plugin enables the ability to build and publish [Docker](https://www.docker.com/) images in a Vela pipeline. Plugin requires the pipeline to run on a worker that provides the plugin elevated access. 

--- a/content/plugins/pipeline/registry/docker.md
+++ b/content/plugins/pipeline/registry/docker.md
@@ -4,228 +4,40 @@ title: "Docker"
 
 ## Overview
 
-This plugin enables the ability to build and publish [Docker](https://www.docker.com/) images in a Vela pipeline.
+{{% alert color="warning" %}}
+This plugin was originally used to build **all** Docker images. The functionality of this plugin still exists within [Kaniko](/kaniko)
+{{% /alert %}}
+
+This plugin enables the ability to build and publish [Docker](https://www.docker.com/) images in a Vela pipeline. Plugin requires the pipeline to run on a worker that provides the plugin elevated access. 
 
 Source Code: https://github.com/go-vela/vela-docker
 
 Registry: https://hub.docker.com/r/target/vela-docker
 
-{{% alert color="tip" %}}
-This plugin supports environment (`PARAMETER_*`) and volume (`/vela/parameters/*`) configuration for setting parameters.
-
-The precedence order is take files then environment variables if both are set in a container.
-{{% /alert %}}
-
 ## Usage
 
-Sample of building and publishing an image:
-
-```yaml
-steps:
-  - name: publish_hello-world
-    image: target/vela-docker:v0.2.1
-    pull: always
-    parameters:
-      registry: index.docker.io
-      repo: index.docker.io/octocat/hello-world
-```
-
-Sample of building an image without publishing:
-
-```diff
-steps:
-  - name: publish_hello-world
-    image: target/vela-docker:v0.2.1
-    pull: always
-    parameters:
-+     dry_run: true
-      registry: index.docker.io
-      repo: index.docker.io/octocat/hello-world
-```
-
-Sample of building and publishing an image with custom tags:
-
-```diff
-steps:
-  - name: publish_hello-world
-    image: target/vela-docker:v0.2.1
-    pull: always
-    parameters:
-      registry: index.docker.io
-      repo: index.docker.io/octocat/hello-world
-+     tags:
-+       - latest
-+       - foobar
-```
-
-Sample of building and publishing an image with automatic tags:
-
-```diff
-steps:
-  - name: publish_hello-world
-    image: target/vela-docker:v0.2.1
-    pull: always
-    parameters:
-+     auto_tag: true
-      registry: index.docker.io
-      repo: index.docker.io/octocat/hello-world
-```
-
-Sample of building and publishing an image with build arguments:
-
-```diff
-steps:
-  - name: publish_hello-world
-    image: target/vela-docker:v0.2.1
-    pull: always
-    parameters:
-+     build_args:
-+       - FOO=bar
-      registry: index.docker.io
-      repo: index.docker.io/octocat/hello-world
-```
-
-Sample of building and publishing an image with caching:
-
-```diff
-steps:
-  - name: publish_hello-world
-    image: target/vela-docker:v0.2.1
-    pull: always
-    parameters:
-+     cache: true
-+     cache_repo: index.docker.io/octocat/hello-world
-      registry: index.docker.io
-      repo: index.docker.io/octocat/hello-world
-```
-
-Sample of building and publishing an image with custom labels:
-
-```diff
-steps:
-  - name: publish_hello-world
-    image: target/vela-docker:v0.2.1
-    pull: always
-    parameters:
-      registry: index.docker.io
-      repo: index.docker.io/octocat/hello-world
-+     labels:
-+       - FOO=bar
-+       - HELLO=world
-```
+COMING SOON!
 
 ## Secrets
 
-{{% alert color="warning" %}}
-Users should refrain from configuring sensitive information in their pipeline in plain text.
-{{% /alert %}}
+COMING SOON!
 
 ### Internal
 
-The plugin accepts the following `parameters` for authentication:
-
-| Parameter   | Environment Variable Configuration                           |
-| ----------- | ------------------------------------------------------------ |
-| `password`  | `DOCKER_PASSWORD`, `REGISTRY_PASSWORD`, `PARAMETER_PASSWORD` |
-| `username`  | `DOCKER_USERNAME`, `REGISTRY_USERNAME`, `PARAMETER_USERNAME` |
-
-Users can use [Vela secrets](/docs/concepts/pipeline/secrets/) to substitute these sensitive values at runtime:
-
-```diff
-steps:
-  - name: publish_hello-world
-    image: target/vela-docker:v0.2.1
-    pull: always
-+   secrets: [ docker_username, docker_password ]
-    parameters:
-      registry: index.docker.io
-      repo: index.docker.io/octocat/hello-world
--     username: octocat
--     password: superSecretPassword
-```
-
-{{% alert color="info" %}}
-This example will add the `secrets` to the `publish_hello-world` step as environment variables:
-
-- `DOCKER_USERNAME`=<value>
-- `DOCKER_PASSWORD`=<value>
-{{% /alert %}}
+COMING SOON!
 
 ### External
 
-The plugin accepts the following files for authentication:
-
-| Parameter   | Volume Configuration                           |
-| ----------- | ------------------------------------------------------------ |
-| `password`  | `/vela/parameters/docker/registry/password`, `/vela/secrets/docker/registry/password`, `/vela/secrets/docker/password` |
-| `username`  | `/vela/parameters/docker/registry/username`, `/vela/secrets/docker/registry/username`, `/vela/secrets/docker/username` |
-
-Users can use [Vela external secrets](/docs/concepts/pipeline/secrets/) to substitute these sensitive values at runtime:
-
-```diff
-steps:
-  - name: publish_hello-world
-    image: target/vela-docker:v0.2.1
-    pull: always
-    parameters:
-      registry: index.docker.io
-      repo: index.docker.io/octocat/hello-world
--     username: octocat
--     password: superSecretPassword
-```
-
-{{% alert color="info" %}}
-This example will read the secrets values in the volume stored at `/vela/secrets/`:
-{{% /alert %}}
+COMING SOON!
 
 ## Parameters
 
-{{% alert color="info" %}}
-Vela injects several variables, by default, that this plugin can load in automatically.
-{{% /alert %}}
-
-The following parameters are used to configure the image:
-
-| Name         | Description                                   | Required | Default           |
-| ------------ | --------------------------------------------- | -------- | ----------------- |
-| `auto_tag`   | enables tagging of image automatically        | `false`  | `false`           |
-| `build_args` | variables passed to image at build-time       | `false`  | `N/A`             |
-| `cache`      | enable caching of image layers                | `false`  | `false`           |
-| `cache_repo` | specific repo to enable caching for           | `false`  | `N/A`             |
-| `context`    | path to context for building the image        | `true`   | `.`               |
-| `dockerfile` | path to the file for building the image       | `true`   | `Dockerfile`      |
-| `dry_run`    | enable building the image without publishing  | `false`  | `false`           |
-| `event`      | event generated for build                     | `true`   | **set by Vela**   |
-| `labels`     | unique labels to add to the image             | `false`  | `N/A`             |
-| `log_level`  | set the log level for the plugin              | `true`   | `info`            |
-| `password`   | password for communication with the registry  | `true`   | `N/A`             |
-| `registry`   | name of the registry for the repository       | `true`   | `index.docker.io` |
-| `repo`       | name of the repository for the image          | `true`   | `N/A`             |
-| `sha`        | SHA-1 hash generated for commit               | `true`   | **set by Vela**   |
-| `tag`        | tag generated for build                       | `false`  | **set by Vela**   |
-| `tags`       | unique tags of the image                      | `true`   | `latest`          |
-| `target`     | set the target build stage                    | `false`  | `N/A`             |
-| `username`   | user name for communication with the registry | `true`   | `N/A`             |
+COMING SOON!
 
 ## Template
 
 COMING SOON!
 
 ## Troubleshooting
-
-You can start troubleshooting this plugin by tuning the level of logs being displayed:
-
-```diff
-steps:
-  - name: publish_hello-world
-    image: target/vela-docker:v0.2.1
-    pull: always
-    parameters:
-+     log_level: trace
-      registry: index.docker.io
-      repo: index.docker.io/octocat/hello-world
-```
-
-Below are a list of common problems and how to solve them:
 
 COMING SOON!

--- a/content/plugins/pipeline/registry/kaniko.md
+++ b/content/plugins/pipeline/registry/kaniko.md
@@ -10,13 +10,11 @@ Source Code: https://github.com/go-vela/vela-kaniko
 
 Registry: https://hub.docker.com/r/target/vela-kaniko
 
-{{% alert color="tip" %}}
-This plugin supports environment (`PARAMETER_*`) and volume (`/vela/parameters/*`) configuration for setting parameters.
-
-The precedence order is take files then environment variables if both are set in a container.
-{{% /alert %}}
-
 ## Usage
+
+{{% alert color="tip" %}}
+* It is not recommended to use `latest` as the tag for the Docker image. Users should use a semantically versioned tag instead.
+{{% /alert %}}
 
 Sample of building and publishing an image:
 
@@ -24,7 +22,7 @@ Sample of building and publishing an image:
 steps:
   - name: publish_hello-world
     image: target/vela-kaniko:latest
-    pull: true
+    pull: always
     parameters:
       registry: index.docker.io
       repo: index.docker.io/octocat/hello-world
@@ -36,7 +34,7 @@ Sample of building an image without publishing:
 steps:
   - name: publish_hello-world
     image: target/vela-kaniko:latest
-    pull: true
+    pull: always
     parameters:
 +     dry_run: true
       registry: index.docker.io
@@ -49,7 +47,7 @@ Sample of building and publishing an image with custom tags:
 steps:
   - name: publish_hello-world
     image: target/vela-kaniko:latest
-    pull: true
+    pull: always
     parameters:
       registry: index.docker.io
       repo: index.docker.io/octocat/hello-world
@@ -64,7 +62,7 @@ Sample of building and publishing an image with automatic tags:
 steps:
   - name: publish_hello-world
     image: target/vela-kaniko:latest
-    pull: true
+    pull: always
     parameters:
 +     auto_tag: true
       registry: index.docker.io
@@ -77,7 +75,7 @@ Sample of building and publishing an image with build arguments:
 steps:
   - name: publish_hello-world
     image: target/vela-kaniko:latest
-    pull: true
+    pull: always
     parameters:
 +     build_args:
 +       - FOO=bar
@@ -91,7 +89,7 @@ Sample of building and publishing an image with caching:
 steps:
   - name: publish_hello-world
     image: target/vela-kaniko:latest
-    pull: true
+    pull: always
     parameters:
 +     cache: true
 +     cache_repo: index.docker.io/octocat/hello-world
@@ -105,7 +103,7 @@ Sample of building and publishing an image with custom labels:
 steps:
   - name: publish_hello-world
     image: target/vela-kaniko:latest
-    pull: true
+    pull: always
     parameters:
       registry: index.docker.io
       repo: index.docker.io/octocat/hello-world
@@ -135,7 +133,7 @@ Users can use [Vela secrets](/docs/concepts/pipeline/secrets/) to substitute the
 steps:
   - name: publish_hello-world
     image: target/vela-kaniko:latest
-    pull: true
+    pull: always
 +   secrets: [ docker_username, docker_password ]
     parameters:
       registry: index.docker.io
@@ -166,7 +164,7 @@ Users can use [Vela external secrets](/docs/concepts/pipeline/secrets/) to subst
 steps:
   - name: publish_hello-world
     image: target/vela-kaniko:latest
-    pull: true
+    pull: always
     parameters:
       registry: index.docker.io
       repo: index.docker.io/octocat/hello-world
@@ -221,7 +219,7 @@ You can start troubleshooting this plugin by tuning the level of logs being disp
 steps:
   - name: publish_hello-world
     image: target/vela-kaniko:latest
-    pull: true
+    pull: always
     parameters:
 +     log_level: trace
       registry: index.docker.io

--- a/content/plugins/pipeline/registry/kaniko.md
+++ b/content/plugins/pipeline/registry/kaniko.md
@@ -4,7 +4,7 @@ title: "Kaniko"
 
 ## Overview
 
-This plugin uses [Kaniko](https://github.com/GoogleContainerTools/kaniko) to provide the ability to build and publish [Docker](https://www.docker.com/) images in a Vela pipeline without evaluated access on the workers.
+This plugin uses [Kaniko](https://github.com/GoogleContainerTools/kaniko) to provide the ability to build and publish [Docker](https://www.docker.com/) images in a Vela pipeline without elevated access on the workers.
 
 Source Code: https://github.com/go-vela/vela-kaniko
 

--- a/content/plugins/pipeline/registry/kaniko.md
+++ b/content/plugins/pipeline/registry/kaniko.md
@@ -1,0 +1,233 @@
+---
+title: "Kaniko"
+---
+
+## Overview
+
+This plugin uses [Kaniko](https://github.com/GoogleContainerTools/kaniko) to provide the ability to build and publish [Docker](https://www.docker.com/) images in a Vela pipeline without evaluated access on the workers.
+
+Source Code: https://github.com/go-vela/vela-kaniko
+
+Registry: https://hub.docker.com/r/target/vela-kaniko
+
+{{% alert color="tip" %}}
+This plugin supports environment (`PARAMETER_*`) and volume (`/vela/parameters/*`) configuration for setting parameters.
+
+The precedence order is take files then environment variables if both are set in a container.
+{{% /alert %}}
+
+## Usage
+
+Sample of building and publishing an image:
+
+```yaml
+steps:
+  - name: publish_hello-world
+    image: target/vela-kaniko:latest
+    pull: true
+    parameters:
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
+```
+
+Sample of building an image without publishing:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-kaniko:latest
+    pull: true
+    parameters:
++     dry_run: true
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
+```
+
+Sample of building and publishing an image with custom tags:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-kaniko:latest
+    pull: true
+    parameters:
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
++     tags:
++       - latest
++       - foobar
+```
+
+Sample of building and publishing an image with automatic tags:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-kaniko:latest
+    pull: true
+    parameters:
++     auto_tag: true
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
+```
+
+Sample of building and publishing an image with build arguments:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-kaniko:latest
+    pull: true
+    parameters:
++     build_args:
++       - FOO=bar
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
+```
+
+Sample of building and publishing an image with caching:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-kaniko:latest
+    pull: true
+    parameters:
++     cache: true
++     cache_repo: index.docker.io/octocat/hello-world
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
+```
+
+Sample of building and publishing an image with custom labels:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-kaniko:latest
+    pull: true
+    parameters:
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
++     labels:
++       - FOO=bar
++       - HELLO=world
+```
+
+## Secrets
+
+{{% alert color="warning" %}}
+Users should refrain from configuring sensitive information in their pipeline in plain text.
+{{% /alert %}}
+
+### Internal
+
+The plugin accepts the following `parameters` for authentication:
+
+| Parameter   | Environment Variable Configuration                           |
+| ----------- | ------------------------------------------------------------ |
+| `password`  | `DOCKER_PASSWORD`, `REGISTRY_PASSWORD`, `PARAMETER_PASSWORD` |
+| `username`  | `DOCKER_USERNAME`, `REGISTRY_USERNAME`, `PARAMETER_USERNAME` |
+
+Users can use [Vela secrets](/docs/concepts/pipeline/secrets/) to substitute these sensitive values at runtime:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-kaniko:latest
+    pull: true
++   secrets: [ docker_username, docker_password ]
+    parameters:
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
+-     username: octocat
+-     password: superSecretPassword
+```
+
+{{% alert color="info" %}}
+This example will add the `secrets` to the `publish_hello-world` step as environment variables:
+
+- `DOCKER_USERNAME`=<value>
+- `DOCKER_PASSWORD`=<value>
+{{% /alert %}}
+
+### External
+
+The plugin accepts the following files for authentication:
+
+| Parameter   | Volume Configuration                           |
+| ----------- | ------------------------------------------------------------ |
+| `password`  | `/vela/parameters/docker/registry/password`, `/vela/secrets/docker/registry/password`, `/vela/secrets/docker/password` |
+| `username`  | `/vela/parameters/docker/registry/username`, `/vela/secrets/docker/registry/username`, `/vela/secrets/docker/username` |
+
+Users can use [Vela external secrets](/docs/concepts/pipeline/secrets/) to substitute these sensitive values at runtime:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-kaniko:latest
+    pull: true
+    parameters:
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
+-     username: octocat
+-     password: superSecretPassword
+```
+
+{{% alert color="info" %}}
+This example will read the secrets values in the volume stored at `/vela/secrets/`:
+{{% /alert %}}
+
+## Parameters
+
+{{% alert color="info" %}}
+* Vela injects several variables, by default, that this plugin can load in automatically.
+* the plugin supports reading all parameters via environment variables or files
+* values set from a file take precedence over values set from the environment
+{{% /alert %}}
+
+The following parameters are used to configure the image:
+
+| Name         | Description                                   | Required | Default           |
+| ------------ | --------------------------------------------- | -------- | ----------------- |
+| `auto_tag`   | enables tagging of image automatically        | `false`  | `false`           |
+| `build_args` | variables passed to image at build-time       | `false`  | `N/A`             |
+| `cache`      | enable caching of image layers                | `false`  | `false`           |
+| `cache_repo` | specific repo to enable caching for           | `false`  | `N/A`             |
+| `context`    | path to context for building the image        | `true`   | `.`               |
+| `dockerfile` | path to the file for building the image       | `true`   | `Dockerfile`      |
+| `dry_run`    | enable building the image without publishing  | `false`  | `false`           |
+| `event`      | event generated for build                     | `true`   | **set by Vela**   |
+| `labels`     | unique labels to add to the image             | `false`  | `N/A`             |
+| `log_level`  | set the log level for the plugin              | `true`   | `info`            |
+| `password`   | password for communication with the registry  | `true`   | `N/A`             |
+| `registry`   | name of the registry for the repository       | `true`   | `index.docker.io` |
+| `repo`       | name of the repository for the image          | `true`   | `N/A`             |
+| `sha`        | SHA-1 hash generated for commit               | `true`   | **set by Vela**   |
+| `tag`        | tag generated for build                       | `false`  | **set by Vela**   |
+| `tags`       | unique tags of the image                      | `true`   | `latest`          |
+| `target`     | set the target build stage                    | `false`  | `N/A`             |
+| `username`   | user name for communication with the registry | `true`   | `N/A`             |
+
+## Template
+
+COMING SOON!
+
+## Troubleshooting
+
+You can start troubleshooting this plugin by tuning the level of logs being displayed:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-kaniko:latest
+    pull: true
+    parameters:
++     log_level: trace
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
+```
+
+Below are a list of common problems and how to solve them:
+
+COMING SOON!

--- a/content/plugins/pipeline/registry/makisu.md
+++ b/content/plugins/pipeline/registry/makisu.md
@@ -1,0 +1,210 @@
+---
+title: "Makisu"
+---
+
+## Description
+
+This plugin uses [Kaniko](https://github.com/uber/makisu) to provide the ability to build and publish [Docker](https://www.docker.com/) images in a Vela pipeline without evaluated access on the workers.
+
+Source Code: https://github.com/go-vela/vela-makisu
+
+Registry: https://hub.docker.com/r/target/vela-makisu
+
+## Usage
+
+{{% alert color="tip" %}}
+* It is not recommended to use `latest` as the tag for the Docker image. Users should use a semantically versioned tag instead.
+{{% /alert %}}
+
+Sample of building and publishing an image:
+
+```yaml
+steps:
+  - name: publish_hello-world
+    image: target/vela-makisu:latest
+    pull: always
+    parameters:
+      registry: index.docker.io
+      tag: index.docker.io/octocat/hello-world
+      pushes: [ index.docker.io ]
+```
+
+Sample of building an image without publishing:
+
+```diff
+steps:
+  - name: publish hello world
+    image: target/vela-makisu:latest
+    pull: always
+    parameters:
+-     pushes: [ index.docker.io ]
+      registry: index.docker.io
+      tag: index.docker.io/octocat/hello-world:latest
+```
+
+Sample of building and publishing an image with custom tags:
+
+```diff
+steps:
+  - name: publish hello world
+    image: target/vela-makisu:latest
+    pull: always
+    parameters:
+      registry: index.docker.io
+      tag: index.docker.io/octocat/hello-world:latest
+      pushes: [ index.docker.io ]
++     replicas:
++       - index.docker.io/octocat/hello-world:1
++       - index.docker.io/octocat/hello-world:foobar
+```
+
+Sample of building and publishing an image with build arguments:
+
+```diff
+steps:
+  - name: publish hello world
+    image: target/vela-makisu:latest
+    pull: always
+    parameters:
++     build_args:
++       - FOO=bar
+      registry: index.docker.io
+      tag: index.docker.io/octocat/hello-world
+      pushes: [ index.docker.io ]
+```
+
+Sample of building and publishing an image with redis caching:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-makisu:latest
+    pull: always
+    parameters:
++     redis_cache_options: 
++       addr: redis.company.com
++       password: superSecretPassword
++       ttl: 7d
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
+      pushes: [ index.docker.io ]
+```
+
+## Secrets
+
+{{% alert color="warning" %}}
+Users should refrain from configuring sensitive information in their pipeline in plain text.
+{{% /alert %}}
+
+### Internal
+
+The plugin accepts the following `parameters` for authentication:
+
+| Parameter   | Environment Variable Configuration                           |
+| ----------- | ------------------------------------------------------------ |
+| `password`  | `DOCKER_PASSWORD`, `REGISTRY_PASSWORD`, `PARAMETER_PASSWORD` |
+| `username`  | `DOCKER_USERNAME`, `REGISTRY_USERNAME`, `PARAMETER_USERNAME` |
+
+Users can use [Vela secrets](/docs/concepts/pipeline/secrets/) to substitute these sensitive values at runtime:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-makisu:latest
+    pull: always
++   secrets: [ docker_username, docker_password, redis_cache ]
+    parameters:
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
+      pushes: [ index.docker.io ]
+-     redis_cache: 
+-       addr: redis.company.com
+-       password: superSecretPassword
+-       ttl: 7d      
+-     username: octocat
+-     password: superSecretPassword
+```
+
+{{% alert color="info" %}}
+This example will add the `secrets` to the `publish_hello-world` step as environment variables:
+
+- `DOCKER_USERNAME`=<value>
+- `DOCKER_PASSWORD`=<value>
+{{% /alert %}}
+
+### External
+
+The plugin accepts the following files for authentication:
+
+| Parameter   | Volume Configuration                           |
+| ----------- | ------------------------------------------------------------ |
+| `password`  | `/vela/parameters/makisu/registry/password`, `/vela/secrets/makisu/registry/password`, `/vela/secrets/makisu/password` |
+| `username`  | `/vela/parameters/makisu/registry/username`, `/vela/secrets/makisu/registry/username`, `/vela/secrets/makisu/username` |
+
+Users can use [Vela external secrets](/docs/concepts/pipeline/secrets/) to substitute these sensitive values at runtime:
+
+```diff
+steps:
+  - name: publish_hello-world
+    image: target/vela-makisu:latest
+    pull: always
+    parameters:
+      registry: index.docker.io
+      repo: index.docker.io/octocat/hello-world
+      pushes: [ index.docker.io ]
+-     redis_cache: 
+-       addr: redis.company.com
+-       password: superSecretPassword
+-       ttl: 7d      
+-     username: octocat
+-     password: superSecretPassword
+```
+
+## Parameters
+
+{{% alert color="info" %}}
+* the plugin supports reading all parameters via environment variables or files
+* values set from a file take precedence over values set from the environment
+{{% /alert %}}
+
+The following parameters are used to configure the build and push process:
+
+| Name              | Description                                                          | Required | Default |
+| ----------------- | -------------------------------------------------------------------- | -------- | ------- |
+| `build_args`      | build time arguments for the Dockerfile                              | `false`  | `N/A`   |
+| `commit`          | commit info for #!COMMIT annotations                                 | `false`  | `N/A`   |
+| `compression`     | compression on the tar file built - options: (no|speed|size|default) | `false`  | `N/A`   |
+| `context`         | the context for the image to be built                                | `false`  | `.`     |
+| `deny_list`       | list of locations to be ignored within docker image                  | `false`  | `N/A`   |
+| `docker`          | configuration on the docker daemon                                   | `false`  | `N/A`   |
+| `destination`     | the output of the tar file                                           | `false`  | `N/A`   |
+| `file`            | a the absolute path to dockerfile                                    | `false`  | `info`  |
+| `http_cache`      | custom http options caching                                          | `false`  | `N/A`   |
+| `load`            | enables loading a docker image into the docker daemon post build     | `false`  | `N/A`   |
+| `local_cache_ttl` | a time to live for the local docker cache (default 168h0m0s)         | `false`  | `N/A`   |
+| `modify_fs`       | makisu to modify files outside its internal storage directories      | `false`  | `N/A`   |
+| `perserve_root`   | copying storage from root in the storage during and after build      | `false`  | `N/A`   |
+| `pushes`          | registries to push the image to                                      | `false`  | `N/A`   |
+| `redis_cache`     | custom redis server for caching                                      | `false`  | `N/A`   |
+| `replicas`        | pushing image to alternative targets i.e. `<registry>/<repo>:<tag>`  | `false`  | `N/A`   |
+| `storage`         | a directory for makisu to use for temp files and cached layers       | `false`  | `N/A`   |
+| `tag`             | the tag for an image                                                 | `true`   | `N/A`   |
+| `storage`         | the target build stage to build                                      | `false`  | `N/A`   |
+
+The following parameters are used to configure the registry:
+
+| Name            | Description                                                        | Required | Default           |
+| --------------- | ------------------------------------------------------------------ | -------- | ----------------- |
+| `mirror`        | name of the mirror registry to use                                 | `false`  | `N/A`             |
+| `password`      | password for communication with the registry                       | `true`   | `N/A`             |
+| `registry`      | name of the registry for the repository                            | `true`   | `index.docker.io` |
+| `repo`          | name of the repository for the image                               | `true`   | `N/A`             |
+| `username`      | user name for communication with the registry                      | `true`   | `N/A`             |
+
+## Template
+
+COMING SOON!
+
+## Troubleshooting
+
+Below are a list of common problems and how to solve them:

--- a/content/plugins/pipeline/registry/makisu.md
+++ b/content/plugins/pipeline/registry/makisu.md
@@ -208,3 +208,5 @@ COMING SOON!
 ## Troubleshooting
 
 Below are a list of common problems and how to solve them:
+
+COMING SOON!

--- a/content/plugins/pipeline/registry/makisu.md
+++ b/content/plugins/pipeline/registry/makisu.md
@@ -4,7 +4,7 @@ title: "Makisu"
 
 ## Description
 
-This plugin uses [Kaniko](https://github.com/uber/makisu) to provide the ability to build and publish [Docker](https://www.docker.com/) images in a Vela pipeline without evaluated access on the workers.
+This plugin uses [Kaniko](https://github.com/uber/makisu) to provide the ability to build and publish [Docker](https://www.docker.com/) images in a Vela pipeline without elevated access on the workers.
 
 Source Code: https://github.com/go-vela/vela-makisu
 

--- a/content/usage/getting-started/docker.md
+++ b/content/usage/getting-started/docker.md
@@ -1,0 +1,56 @@
+---
+title: "Building Docker Images"
+toc: true
+weight: 7
+description: >
+  Understanding the options for how to build a Dockerfile
+---
+
+We assume you understand how to build and run Docker images. If you need assistance on how to get started with Docker we recommend you see their documentation for [getting set up](https://docs.docker.com/get-started/).
+
+Vela runs all workloads within Docker containers. Which essentially gives us two core different ways to build Docker images:
+
+* Without elevated daemon access
+* With elevated daemon access
+
+Both options have disadvantages and advantages, so we encourage all Vela administrators to way the pros/cons of how they want to build Docker images for their cluster.
+
+## Without elevated daemon access
+
+Building an image without elevated access gives administrators the most secure pattern for not allowing any elevated access to the workers within the cluster. There are two plugin options for building those images:
+
+* [vela-kaniko](/docs/plugins/pipeline/registry/kaniko/)
+* [vela-makisu](/docs/plugins/pipeline/registry/makisu/)
+
+We recommend customers read the [tool comparisons](/docs/usage/getting-started/docker/#additional-resources) before picking a technology for building their images. In-depth examples for building with either utility are available within their respective plugin documentation pages. A simple example is provided below:
+
+```diff
+version: "1"
+steps:
++ - name: build and publish with kaniko
++   image: target/vela-kaniko:latest
++   pull: always
++   parameters:
++     registry: index.docker.io
++     repo: index.docker.io/octocat/hello-world
+
++ - name: build and publish with makisu
++   image: target/vela-makisu:latest
++   pull: always
++   parameters:
++     registry: index.docker.io
++     tag: index.docker.io/octocat/hello-world
++     pushes: [ index.docker.io ]
+```
+
+## With elevated daemon access
+
+COMING SOON!
+
+## Additional Resources
+
+* [Building Container Images Securely on Kubernetes](https://blog.jessfraz.com/post/building-container-images-securely-on-kubernetes/)
+* [Why is building rootless so hard?](https://github.com/opencontainers/runc/pull/1692)
+* [Introducing Makisu](https://eng.uber.com/makisu/)
+* [Kaniko tools comparison](https://github.com/GoogleContainerTools/kaniko#comparison-with-other-tools)
+* [Makisu tools comparison](https://github.com/uber/makisu#comparison-with-similar-tools)

--- a/content/usage/getting-started/docker.md
+++ b/content/usage/getting-started/docker.md
@@ -6,14 +6,14 @@ description: >
   Understanding the options for how to build a Dockerfile
 ---
 
-We assume you understand how to build and run Docker images. If you need assistance on how to get started with Docker we recommend you see their documentation for [getting set up](https://docs.docker.com/get-started/).
+We assume you understand how to build and run Docker images. If you need assistance on how to get started with Docker; we recommend you see their documentation for [getting set up](https://docs.docker.com/get-started/).
 
 Vela runs all workloads within Docker containers. Which essentially gives us two core different ways to build Docker images:
 
 * Without elevated daemon access
 * With elevated daemon access
 
-Both options have disadvantages and advantages, so we encourage all Vela administrators to way the pros/cons of how they want to build Docker images for their cluster.
+Both options have disadvantages and advantages, so we encourage all Vela administrators to weigh the pros/cons of how they want to build Docker images for their cluster.
 
 ## Without elevated daemon access
 


### PR DESCRIPTION
Listed changes for plugin docs:

* Removed content from Docker, and point to Kaniko
* Added new section for Kaniko docs
* Added new section for Makisu docs


Listed changes for usage docs:

* Add content for how to build docker images within Vela