### PR TITLE
fix(render): adding unsafe markup rendering for local development

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -109,3 +109,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/go-vela/docs/issues
 	url = "mailto:vela@target.com"
 	icon = "fa fa-envelope"
         desc = "Discuss development issues around the project"
+
+# Markup Rendering Configurations
+[markup.goldmark.renderer]
+unsafe= true


### PR DESCRIPTION
## Bug
Markdown that renders to raw html is omitted by Hugo during local development, making it difficult to verify some markdown like alerts

### Steps to reproduce:
```bash
$ hugo version
Hugo Static Site Generator v0.76.5/extended darwin/amd64 BuildDate: unknown

$ hugo serve -D
```

### Example of HTML Omission
![Screen Shot 2020-11-10 at 10 50 28 AM](https://user-images.githubusercontent.com/48764154/98704783-a9e36d80-2342-11eb-9039-44473b7daeb7.png)

Adding renderer flag `unsafe= true` to config.toml to allow raw html rendering when doing local development
### Before
![Screen Shot 2020-11-10 at 10 47 39 AM](https://user-images.githubusercontent.com/48764154/98705137-ffb81580-2342-11eb-8076-42c6f9a7eb4e.png)

### After
![Screen Shot 2020-11-10 at 10 47 27 AM](https://user-images.githubusercontent.com/48764154/98705154-05adf680-2343-11eb-849c-84c856c8b860.png)

Solution Reference:
https://discourse.gohugo.io/t/raw-html-getting-omitted-in-0-60-0/22032