### PR TITLE
docs(delete): remove pages without content to avoid confusion

### DIFF
--- a/content/concepts/plugin.md
+++ b/content/concepts/plugin.md
@@ -1,8 +1,0 @@
----
-title: "Plugin"
-linkTitle: "Plugin"
-description: >
-  This section contains information on the plugin component.
----
-
-COMING SOON!

--- a/content/concepts/template.md
+++ b/content/concepts/template.md
@@ -1,8 +1,0 @@
----
-title: "Template"
-linkTitle: "Template"
-description: >
-  This section contains information on the template component.
----
-
-COMING SOON!


### PR DESCRIPTION
These pages are adding some confusion internally since https://go-vela.github.io/docs/plugins/ and https://go-vela.github.io/docs/templates/ already exist with valid content.