### PR TITLE
feat(ref): add a yaml section

### DIFF
--- a/content/reference/yaml/_index.md
+++ b/content/reference/yaml/_index.md
@@ -24,7 +24,7 @@ See YAML [design goals](https://yaml.org/spec/1.2/spec.html#Introduction) from s
 
 ## Terminology Check
 
-Whether you are a YAML expert or a novice here is some quick terminology that is used without the Vela reference documentation you should be aware of:
+Whether you are a YAML expert or a novice, here is some quick terminology that you should be aware of:
 
 {{% alert title="Tip:" color="info" %}}
 You can get feedback directly on your `.vela.yml` or `.vela.yaml` pipelines in your IDE with the available [JSON Schema](/docs/usage/schema/). 

--- a/content/reference/yaml/_index.md
+++ b/content/reference/yaml/_index.md
@@ -1,0 +1,63 @@
+---
+title: "YAML"
+linkTitle: "YAML"
+layout: reference
+description: >
+  reference information for creating Vela pipelines
+---
+
+Steps and Stages Pipeline use "YAML Ain’t Markup Language" (YAML) which is a data serialization language designed to be human friendly. Vela accepts YAML fles with either a `.yml` or `.yaml` extension. If need to learn more about the YAML language we recommend to, see "[Learn YAML in five minutes.](https://www.codeproject.com/Articles/1214409/Learn-YAML-in-five-minutes)".
+
+{{% alert title="Tip:" color="info" %}}
+The design goals for YAML are, in decreasing priority:
+
+1. YAML is easily readable by humans.
+2. YAML data is portable between programming languages.
+3. YAML matches the native data structures of agile languages.
+4. YAML has a consistent model to support generic tools.
+5. YAML supports one-pass processing.
+6. YAML is expressive and extensible.
+7. YAML is easy to implement and use.
+
+See YAML [design goals](https://yaml.org/spec/1.2/spec.html#Introduction) from spec.
+{{% /alert %}}
+
+## Terminology Check
+
+Whether you are a YAML expert or a novice here is some quick terminology that is used without the Vela reference documentation you should be aware of:
+
+{{% alert title="Tip:" color="info" %}}
+You can get feedback directly on your `.vela.yml` or `.vela.yaml` pipelines in your IDE with the available [JSON Schema](/docs/usage/schema/). 
+{{% /alert %}}
+
+### Document
+
+A file ending with `.yml` or `.yaml` that contains contents following the YAML spec is called a document, see [YAML 1.2 spec for full details](https://yaml.org/spec/1.2/spec.html#id2800132).
+
+Example:
+
+```yml
+---
+key: value
+```
+
+### Tags
+
+A YAML document is compose of one to many key value pairs where the key is called the tag and the value is evaluated to an explicit type (Int, Float, string, bool, etc), see [YAML 1.2 spec for full details](https://yaml.org/spec/1.2/spec.html#id2761292).
+
+Example:
+
+```yml
+---
+# an integer
+canonical: 12345
+
+# a float
+canonical: 3.14159e+3
+
+# a string
+canonical: "Hello, World"
+
+# a bool
+canonical: true
+```

--- a/content/reference/yaml/_index.md
+++ b/content/reference/yaml/_index.md
@@ -6,7 +6,7 @@ description: >
   reference information for creating Vela pipelines
 ---
 
-Steps and Stages Pipeline use "YAML Ain’t Markup Language" (YAML) which is a data serialization language designed to be human friendly. Vela accepts YAML fles with either a `.yml` or `.yaml` extension. If need to learn more about the YAML language we recommend to, see "[Learn YAML in five minutes.](https://www.codeproject.com/Articles/1214409/Learn-YAML-in-five-minutes)".
+Steps and Stages Pipeline use "YAML Ain’t Markup Language" (YAML) which is a data serialization language designed to be human friendly. Vela accepts YAML fles with either a `.yml` or `.yaml` extension. If you'd like to learn more about the YAML language, we recommend you see, "[Learn YAML in five minutes.](https://www.codeproject.com/Articles/1214409/Learn-YAML-in-five-minutes)".
 
 {{% alert title="Tip:" color="info" %}}
 The design goals for YAML are, in decreasing priority:

--- a/content/reference/yaml/_index.md
+++ b/content/reference/yaml/_index.md
@@ -6,7 +6,7 @@ description: >
   reference information for creating Vela pipelines
 ---
 
-Steps and Stages Pipeline use "YAML Ain’t Markup Language" (YAML) which is a data serialization language designed to be human friendly. Vela accepts YAML fles with either a `.yml` or `.yaml` extension. If you'd like to learn more about the YAML language, we recommend you see, "[Learn YAML in five minutes.](https://www.codeproject.com/Articles/1214409/Learn-YAML-in-five-minutes)".
+Steps and Stages Pipeline use "YAML Ain’t Markup Language" (YAML) which is a data serialization language designed to be human friendly. Vela accepts YAML files with either a `.yml` or `.yaml` extension. If you'd like to learn more about the YAML language, we recommend you see, "[Learn YAML in five minutes.](https://www.codeproject.com/Articles/1214409/Learn-YAML-in-five-minutes)".
 
 {{% alert title="Tip:" color="info" %}}
 The design goals for YAML are, in decreasing priority:
@@ -43,7 +43,7 @@ key: value
 
 ### Tags
 
-A YAML document is compose of one to many key value pairs where the key is called the tag and the value is evaluated to an explicit type (Int, Float, string, bool, etc), see [YAML 1.2 spec for full details](https://yaml.org/spec/1.2/spec.html#id2761292).
+A YAML document is compose of one to many key-value pairs where the key is called the tag and the value is evaluated to an explicit type (Int, Float, string, bool, etc), see [YAML 1.2 spec for full details](https://yaml.org/spec/1.2/spec.html#id2761292).
 
 Example:
 

--- a/content/reference/yaml/metadata.md
+++ b/content/reference/yaml/metadata.md
@@ -1,0 +1,51 @@
+---
+title: "Metadata"
+linkTitle: "Metadata"
+weight: 2
+description: >
+  YAML tags for metadata block
+---
+
+The metadata tag is intended to be used during the compile phase to signal how to treat the YAML document.
+
+```yaml
+---
+# This document is displaying all the available tags
+# in their default state for the compile process.
+metadata:
+  template: false
+  clone: true
+```
+
+## Tags
+
+| Tag        | Required | Type | Description                                   |
+|------------|----------|------|-----------------------------------------------|
+| `template` | Y        | bool | Enables compiling the pipeline as a template. |
+| `clone`    | N        | bool | Enables injecting the default clone process.  |
+
+### Usage
+
+#### The `template:` tag
+
+{{% alert title="Tip:" color="info" %}}
+To learn how to write templates, see the [template documentation](/docs/templates).
+{{% /alert %}}
+
+```yaml
+---
+metadata:
+  # Enables compiling the pipeline as a template. This value 
+  # is defaulted during the compile phase to "false" if not 
+  # explicitly provided by the user.
+  template: true
+```
+
+#### The `clone:` tag
+
+```yaml
+---
+metadata:
+  # Enables injecting the default clone process
+  clone: true
+```

--- a/content/reference/yaml/secrets.md
+++ b/content/reference/yaml/secrets.md
@@ -6,8 +6,7 @@ description: >
   YAML tags for secret block
 ---
 
-The secret tag is intended to be used to pull secrets from the Vela server or execute 
-plugins to write the external secrets to the build volume.
+The secret tag is intended to be used to pull secrets from the Vela server or execute plugins to write the external secrets to the build volume.
 
 ```yaml
 ---

--- a/content/reference/yaml/secrets.md
+++ b/content/reference/yaml/secrets.md
@@ -123,7 +123,7 @@ secrets:
 | Tag           | Required | Type            | Description                                                      |
 |---------------|----------|-----------------|------------------------------------------------------------------|
 | `name`        | Y        | string          | Unique identifier for the container in the pipeline.             |
-| `image`       | Y        | []string        | Docker image used to create ephemeral container.                 |
+| `image`       | Y        | []string        | Docker image used to create an ephemeral container.                 |
 | `pull`        | N        | string          | Declaration to configure if and when the Docker image is pulled. |
 | `secrets`     | N        | struct          | Sensitive variables injected into the container environment.     |
 | `environment` | N        | map || []string | Variables to inject into the container environment.              |

--- a/content/reference/yaml/secrets.md
+++ b/content/reference/yaml/secrets.md
@@ -24,11 +24,11 @@ secrets:
     engine: native
     type: repo
   - name: foo2
-    key: go-vela/foo`
+    key: go-vela/foo2`
     engine: native
     type: org
   - name: foo3
-    key: go-vela/admins/foo
+    key: go-vela/admins/foo3
     engine: native
     type: shared
 
@@ -112,8 +112,8 @@ secrets:
 ```yaml
 ---
 secrets: 
-    # Type of secret to fetch from storage backend. By default, Vela 
-    # can pull repo but tag accepts the 
+    # Type of secret to fetch from storage backend.
+    # By default, Vela can pull repo but tag accepts the 
     # following values: repo, org, and shared
   - type: repo
 ```
@@ -131,5 +131,5 @@ secrets:
 | `parameters`  | N        | map             | Extra configuration variables specific to a plugin.              |
 
 {{% alert title="Tip:" color="info" %}}
-In an effort to not duplicate how documentation, to see how tags can be set, see the comparable [step tags documentation](/docs/reference/yaml/steps/#tags) to get behavior details.
+In an effort to reduce duplicate documentation, see the comparable [step tags documentation](/docs/reference/yaml/steps/#tags) to learn how tags can be set and details on behavior.
 {{% /alert %}}

--- a/content/reference/yaml/secrets.md
+++ b/content/reference/yaml/secrets.md
@@ -1,0 +1,135 @@
+---
+title: "Secrets"
+linkTitle: "Secrets"
+weight: 8
+description: >
+  YAML tags for secret block
+---
+
+The secret tag is intended to be used to pull secrets from the Vela server or execute 
+plugins to write the external secrets to the build volume.
+
+```yaml
+---
+# This document is displaying all the required tags
+# to pull various secret types. 
+secrets: 
+  # Below is displaying the implicit native secret definition. This definition 
+  # is only supported for native secrets of repository type.
+  - name: foo
+
+  # Below is displaying the declarative secret definitions.
+  - name: foo1
+    key: go-vela/docs/foo1
+    engine: native
+    type: repo
+  - name: foo2
+    key: go-vela/foo`
+    engine: native
+    type: org
+  - name: foo3
+    key: go-vela/admins/foo
+    engine: native
+    type: shared
+
+  # Below is displaying executing a secret plugin.
+  - origin:
+     name: External Vault Secret
+     image: target/secret-vault:latest
+     parameters:
+       addr: vault.company.com
+       auth_method: token
+       username: vela
+       token: sometoken
+       items:
+         - source: secret/vela
+           path: user    
+```
+
+## Tags
+
+| Tag     | Required | Type   | Description                                                     |
+|---------|----------|--------|-----------------------------------------------------------------|
+| `name`  | Y        | string | Name of secret to reference in the pipeline.                    |
+| `key`   | N        | string | Path to secret to fetch from storage backend.                   |
+| `engine`| N        | string | Name of storage backend to fetch secret from.                   |
+| `type`  | N        | string | Type of secret to fetch from storage backend.                   |
+| `origin`| N        | struct | Declaration to pull secrets from non-internal secret providers. |
+
+#### The `name:` tag
+
+```yaml
+---
+secrets: 
+    # Name of secret to reference in the pipeline.
+  - name: postgres
+```
+
+#### The `key:` tag
+
+{{% alert title="Tip:" color="info" %}}
+The key is unique
+    # to the type of secret you need to pull and follows a pattern
+    # to ensure the repo has the proper authorization to use the secret.
+    # Pattern by type:
+    # repo    - <org>/<repo>/<some_name>
+    # org     - <org>/<some_name>
+    # shared  - <org>/<team_with_org>/<some_name>
+{{% /alert %}}
+
+```yaml
+---
+secrets: 
+    # Path to secret to fetch from storage backend. Displaying a 
+    # repo type secret. 
+  - key: go-vela/docs/foo1
+
+    # Path to secret to fetch from storage backend. Displaying a 
+    # org type secret.
+  - key: go-vela/foo1
+  
+    # Path to secret to fetch from storage backend. Displaying a 
+    # shared type secret.
+  - key: go-vela/admins/foo1  
+```
+
+#### The `engine:` tag
+
+{{% alert title="Tip:" color="info" %}}
+To know what engines are available for your Vela installation, we recommend consulting your system administrators.
+{{% /alert %}}
+
+```yaml
+---
+secrets: 
+    # Name of storage backend to fetch secret from, "native" signifies
+    # the backend provide it the Vela database. 
+  - engine: native
+```
+
+#### The `type:` tag
+
+```yaml
+---
+secrets: 
+    # Type of secret to fetch from storage backend. By default, Vela 
+    # can pull repo but tag accepts the 
+    # following values: repo, org, and shared
+  - type: repo
+```
+
+#### The `origin:` tag
+
+| Tag           | Required | Type            | Description                                                      |
+|---------------|----------|-----------------|------------------------------------------------------------------|
+| `name`        | Y        | string          | Unique identifier for the container in the pipeline.             |
+| `image`       | Y        | []string        | Docker image used to create ephemeral container.                 |
+| `pull`        | N        | string          | Declaration to configure if and when the Docker image is pulled. |
+| `secrets`     | N        | struct          | Sensitive variables injected into the container environment.     |
+| `environment` | N        | map || []string | Variables to inject into the container environment.              |
+| `ruleset`     | N        | struct          | Conditions to limit the execution of the container.              |
+| `parameters`  | N        | map             | Extra configuration variables specific to a plugin.              |
+
+{{% alert title="Tip:" color="info" %}}
+In an effort to not duplicate how documentation, to see how tags can be set, see the comparable [step tags documentation](/docs/reference/yaml/steps/#tags) to get behavior details.
+{{% /alert %}}

--- a/content/reference/yaml/services.md
+++ b/content/reference/yaml/services.md
@@ -74,7 +74,7 @@ services:
 ---
 services: 
     # Variables to injected into the container environment
-    # using a array style syntax.
+    # using an array style syntax.
   - environment:
       - DB_NAME=vela
 ```

--- a/content/reference/yaml/services.md
+++ b/content/reference/yaml/services.md
@@ -1,0 +1,101 @@
+---
+title: "Services"
+linkTitle: "Services"
+weight: 5
+description: >
+  YAML tags for services block
+---
+
+The services tag is intended to be used to run applications alongside the pipeline.
+
+```yaml
+---
+# This document is displaying all the required tags
+# to run a postgre database for the duration of a pipeline.
+services: 
+  - name: postgres
+    image: postgres:latest
+```
+
+## Tags
+
+| Tag           | Required | Type            | Description                                                     |
+|---------------|----------|-----------------|-----------------------------------------------------------------|
+| `name`        | Y        | string          | Unique identifier for the container in the pipeline             |
+| `image`       | Y        | []string        | Docker image used to create ephemeral container                 |
+| `pull`        | N        | string          | Declaration to configure if and when the Docker image is pulled |
+| `environment` | N        | map || []string | Variables to inject into the container environment              |
+| `entrypoint`  | N        | []string        | Commands to execute inside the container                        |
+| `ports`       | N        | string          | List of ports to map for the container in the pipeline          |
+
+### Usage
+
+#### The `name:` tag
+
+```yaml
+---
+services: 
+    # Unique identifier for the container in the pipeline.
+  - name: postgres
+```
+
+#### The `image:` tag
+
+```yaml
+---
+services: 
+    # Docker image used to create ephemeral container.
+  - image: postgres:latest
+```
+
+#### The `pull:` tag
+
+```yaml
+---
+services: 
+    # Declaration to configure if and when the Docker image is pulled.
+    # By default, the compiler will inject pull but accepts the 
+    # following values: always, never, no_present, on_start, 
+  - pull: always
+```
+
+#### The `environment:` tag
+
+```yaml
+---
+services: 
+    # Variables to injected into the container environment
+    # using a map style syntax.
+  - environment:
+      DB_NAME: vela
+```
+
+```yaml
+---
+services: 
+    # Variables to injected into the container environment
+    # using a array style syntax.
+  - environment:
+      - DB_NAME=vela
+```
+
+#### The `entrypoint:` tag
+
+```yaml
+---
+services: 
+    # Commands to execute inside the container.
+  - entrypoint:
+      - some/path/sql-init.sql
+      - /some/binary/postgres
+```
+
+#### The `ports:` tag
+
+```yaml
+---
+services: 
+    # List of ports to map for the container in the pipeline.
+  - ports: 
+      - "8080:5432"
+```

--- a/content/reference/yaml/services.md
+++ b/content/reference/yaml/services.md
@@ -22,7 +22,7 @@ services:
 | Tag           | Required | Type            | Description                                                     |
 |---------------|----------|-----------------|-----------------------------------------------------------------|
 | `name`        | Y        | string          | Unique identifier for the container in the pipeline             |
-| `image`       | Y        | []string        | Docker image used to create ephemeral container                 |
+| `image`       | Y        | []string        | Docker image used to create an ephemeral container                 |
 | `pull`        | N        | string          | Declaration to configure if and when the Docker image is pulled |
 | `environment` | N        | map || []string | Variables to inject into the container environment              |
 | `entrypoint`  | N        | []string        | Commands to execute inside the container                        |

--- a/content/reference/yaml/services.md
+++ b/content/reference/yaml/services.md
@@ -6,7 +6,7 @@ description: >
   YAML tags for services block
 ---
 
-The services tag is intended to be used to run applications alongside the pipeline.
+The `services` tag is intended to be used to run applications alongside the pipeline.
 
 ```yaml
 ---

--- a/content/reference/yaml/services.md
+++ b/content/reference/yaml/services.md
@@ -11,7 +11,7 @@ The services tag is intended to be used to run applications alongside the pipeli
 ```yaml
 ---
 # This document is displaying all the required tags
-# to run a postgre database for the duration of a pipeline.
+# to run a postgres database for the duration of a pipeline.
 services: 
   - name: postgres
     image: postgres:latest

--- a/content/reference/yaml/stages.md
+++ b/content/reference/yaml/stages.md
@@ -6,7 +6,7 @@ description: >
   YAML stages for stages block
 ---
 
-The stages tag is intended to be used to one to many sets of steps tasks in parallel.
+The `stages` tag is intended to be used to parallelize one-to-many sets of step tasks.
 
 ```yaml
 ---
@@ -61,7 +61,7 @@ stages:
 #### The `steps:` tag
 
 {{% alert title="Tip:" color="info" %}}
-To see how all steps tags, see the [step tags documentation](/docs/reference/yaml/steps/#tags)
+For more details on steps tags, see the [step tags documentation](/docs/reference/yaml/steps/#tags)
 {{% /alert %}}
 
 ```yaml

--- a/content/reference/yaml/stages.md
+++ b/content/reference/yaml/stages.md
@@ -1,0 +1,76 @@
+---
+title: "Stages"
+linkTitle: "Stages"
+weight: 7
+description: >
+  YAML stages for stages block
+---
+
+The stages tag is intended to be used to one to many sets of steps tasks in parallel.
+
+```yaml
+---
+# This document is displaying all the required tags
+# to run two stages with one step task in parallel.
+stages:
+  test:
+    hello:
+      - name: Hello World
+        image: alpine:latest
+        commands:
+          - echo "Hello, Vela User"
+
+  welcome:
+    steps:
+      - name: Welcome to Vela
+        image: alpine:latest
+        commands:
+          - echo "Welcome to Vela!"
+```
+
+## Tags
+
+| Tag     | Required | Type     | Description                                               |
+|---------|----------|----------|-----------------------------------------------------------|
+| `name`  | Y        | string   | Unique identifier for the stage in the pipeline           |
+| `steps` | Y        | []string | Sequential execution instructions for the stage           |
+| `needs` | N        | struct   | Stages that must complete before starting the current one |
+
+### Usage
+
+#### The `name:` tag
+
+```yaml
+---
+stages:
+    # Unique identifier for the stage in the pipeline.
+    welcome:
+```
+
+#### The `steps:` tag
+
+```yaml
+---
+stages:
+    # Unique identifier for the stage in the pipeline.
+    welcome:
+      # Sequential execution instructions for the stage.
+      steps:
+```
+
+#### The `steps:` tag
+
+{{% alert title="Tip:" color="info" %}}
+To see how all steps tags, see the [step tags documentation](/docs/reference/yaml/steps/#tags)
+{{% /alert %}}
+
+```yaml
+---
+stages:
+    greeting:
+
+    # Unique identifier for the stage in the pipeline.
+    welcome:
+      # Stages that must complete before starting the current one.
+      needs: [ greeting ]
+```

--- a/content/reference/yaml/steps.md
+++ b/content/reference/yaml/steps.md
@@ -109,7 +109,7 @@ steps:
 ---
 steps:
     # Variables to injected into the container environment
-    # using a array style syntax.
+    # using an array style syntax.
   - environment:
       - DB_NAME=vela
 ```

--- a/content/reference/yaml/steps.md
+++ b/content/reference/yaml/steps.md
@@ -31,7 +31,7 @@ steps:
 | `ruleset`     | N        | struct          | Conditions to limit the execution of the container.              |
 | `parameters`  | N        | map             | Extra configuration variables specific to a plugin.              |
 | `commands`    | N        | []string        | Execution instructions to run inside the container.              |
-| `template`    | N        | struct          | Name of template to expand in the pipeline.                      |
+| `template`    | N        | struct          | Name of a template to expand in the pipeline.                      |
 | `entrypoint`  | N        | []string        | Commands to execute inside the container.                        |
 | `detach`      | N        | []string        | Run the container in a detached (headless) state.                |
 | `volume`      | N        | string          | Mount volumes for the container.                                 |
@@ -118,16 +118,16 @@ steps:
 
 The following rules can be used to configure a ruleset:
 
-| Name      | Description                          |
-|-----------|--------------------------------------|
-| `branch`  | name of branch for build.            |
-| `comment` | pull request comment body.           |
-| `event`   | name of event for build.             |
-| `path`    | path to workspace files for build.   |
-| `repo`    | name of repo for build.              |
-| `status`  | name of status for build.            |
-| `tag`     | name of reference for build.         |
-| `target`  | name of deployment target for build. |
+| Name      | Description                            |
+|-----------|----------------------------------------|
+| `branch`  | name of branch for a build.            |
+| `comment` | pull request comment body.             |
+| `event`   | name of an event for a build.          |
+| `path`    | path to workspace files for a build.   |
+| `repo`    | name of the  repo for a build.         |
+| `status`  | name of status for a build.            |
+| `tag`     | name of reference for a build.         |
+| `target`  | name of deployment target for a build. |
 
 ```yaml
 ---
@@ -172,7 +172,7 @@ steps:
 steps:
   - ruleset:
       # Below is displaying it will run a step if repo exists within the target GitHub
-      # organizatio or the repo is the go-vela/docs repository.
+      # organization or the repo is the go-vela/docs repository.
       repo: [ "target/*", "go-vela/docs" ]
 ```
 
@@ -372,7 +372,7 @@ steps:
 ---
 steps:
     # Set the user limits for the container.  
-  - umlimits:
+  - ulimits:
       - name: foo
         soft: 1024
       - name: bar

--- a/content/reference/yaml/steps.md
+++ b/content/reference/yaml/steps.md
@@ -1,0 +1,390 @@
+---
+title: "Steps"
+linkTitle: "Steps"
+weight: 6
+description: >
+  YAML tags for steps block
+---
+
+The steps tag is intended to be used to run sequential tasks in a pipeline.
+
+```yaml
+---
+# This document is displaying all the required tags
+# to run a postgre database for the duration of a pipeline.
+steps: 
+  - name: Hello World
+    image: alpine:latest
+    commands:
+      - echo "Hello, Vela User"
+```
+
+## Tags
+
+| Tag           | Required | Type            | Description                                                      |
+|---------------|----------|-----------------|------------------------------------------------------------------|
+| `name`        | Y        | string          | Unique identifier for the container in the pipeline.             |
+| `image`       | Y        | []string        | Docker image used to create ephemeral container.                 |
+| `pull`        | N        | string          | Declaration to configure if and when the Docker image is pulled. |
+| `secrets`     | N        | struct          | Sensitive variables injected into the container environment.     |
+| `environment` | N        | map || []string | Variables to inject into the container environment.              |
+| `ruleset`     | N        | struct          | Conditions to limit the execution of the container.              |
+| `parameters`  | N        | map             | Extra configuration variables specific to a plugin.              |
+| `commands`    | N        | []string        | Execution instructions to run inside the container.              |
+| `template`    | N        | struct          | Name of template to expand in the pipeline.                      |
+| `entrypoint`  | N        | []string        | Commands to execute inside the container.                        |
+| `detach`      | N        | []string        | Run the container in a detached (headless) state.                |
+| `volume`      | N        | string          | Mount volumes for the container.                                 |
+| `ulimits`     | N        | string          | Set the user limits for the container.                           |
+| `privileged`  | N        | string          | Run the container with extra privileges.                         |
+
+
+### Usage
+
+#### The `name:` tag
+
+```yaml
+---
+steps:
+    # Unique identifier for the container in the pipeline.
+  - name: Hello World
+```
+
+#### The `image:` tag
+
+```yaml
+---
+steps:
+    # Docker image used to create ephemeral container. 
+  - image: alpine:latest
+```
+
+#### The `pull:` tag
+
+```yaml
+---
+steps:
+    # Declaration to configure if and when the Docker image is pulled.
+    # By default, the compiler will inject pull but accepts the 
+    # following values: always, never, no_present, on_start, 
+  - pull: always
+```
+
+#### The `secrets:` tag
+
+```yaml
+---
+steps:
+    # Sensitive variables to injected into the container
+    # environment as upper case env. i.e. GIT_USERNAME=vela
+  - secrets: [ git_username ]
+```
+
+```yaml
+---
+steps:
+    # Sensitive variables to injected into the container
+    # environment as upper case env. i.e. GIT_USERNAME=<secret_value> 
+  - secrets: 
+      # The source is the "name:" of a secret within the
+      # parent "secrets:" yaml tag
+      - source: username
+      # The target is the desired environment key accessible during
+      # the container runtime.
+        target: git_username
+```
+
+#### The `environment:` tag
+
+```yaml
+---
+steps:
+    # Variables to injected into the container environment
+    # using a map style syntax.
+  - environment:
+      DB_NAME: vela
+```
+
+```yaml
+---
+steps:
+    # Variables to injected into the container environment
+    # using a array style syntax.
+  - environment:
+      - DB_NAME=vela
+```
+
+#### The `ruleset:` tag
+
+The following rules can be used to configure a ruleset:
+
+| Name      | Description                          |
+|-----------|--------------------------------------|
+| `branch`  | name of branch for build.            |
+| `comment` | pull request comment body.           |
+| `event`   | name of event for build.             |
+| `path`    | path to workspace files for build.   |
+| `repo`    | name of repo for build.              |
+| `status`  | name of status for build.            |
+| `tag`     | name of reference for build.         |
+| `target`  | name of deployment target for build. |
+
+```yaml
+---
+steps:
+  - ruleset:
+      # Below is displaying a step that would execute if the build
+      # branch is stage or master.
+      branch: [ stage, master ]
+```
+
+```yaml
+---
+steps:
+  - ruleset:
+      # This extends the ability to start new builds through interactions
+      # within a pull request. Below is displaying it will run a step if a “run build”
+      # comment is added to the bottom of a pull request.
+      comment: [ "run build" ]
+```
+
+```yaml
+---
+steps:
+  - ruleset:
+      # Below is displaying a step that would execute if the build
+      # event is push or pull_request. The available events are:
+      # comment, push, pull_request, tag, and deployment.
+      event: [ push, pull_request ]
+```
+
+```yaml
+---
+steps:
+  - ruleset:
+      # Below is displaying it will run a step if file README.md, any file of type *.md
+      # in the root directory or any file in the test/* directory has changed.
+      path: [ README.md, "*.md", "test/*" ]
+```
+
+```yaml
+---
+steps:
+  - ruleset:
+      # Below is displaying it will run a step if repo exists within the target GitHub
+      # organizatio or the repo is the go-vela/docs repository.
+      repo: [ "target/*", "go-vela/docs" ]
+```
+
+```yaml
+---
+steps:
+  - ruleset:
+      # Below is displaying it will run a step if the build status is failure or success.
+      status: [ failure, success ]
+```
+
+```yaml
+---
+steps:
+  - ruleset:
+      # Below is displaying it will run a step if the build ref is dev/* or test/*.
+      tag: [ dev/*, test/* ]
+```
+
+```yaml
+---
+steps:
+  - ruleset:
+      # Below is displaying it will run a step if the build target is stage or production.
+      # This tag is only compatible with deployment events.
+      target: [ dev/*, test/* ]
+```
+
+The following controls can be used to modify the behavior of the ruleset evaluation:
+
+| Name       | Description                                        |
+|------------|----------------------------------------------------|
+| `continue` | enables continuing the build if the step fails.    |
+| `if`       | limits the step execution to all rules must match. |
+| `matcher`  | matcher to use when evaluating the ruleset.        |
+| `operator` | operator to use when evaluating the ruleset.       |
+| `unless`   | limits the step execution to no rules can match.   |
+
+```yaml
+---
+steps:
+  - ruleset:
+      # Below is displaying it will allow the step to continue the sequential step
+      # pipeline when this step fails.
+      continue: true
+```
+
+```yaml
+---
+steps:
+  - ruleset:
+      # Below is displaying it will is an explicit way to tell the ruleset
+      # to only execute this step when the branch is master and event is push.
+      if:
+        branch: master
+        event: push
+```
+
+```yaml
+---
+steps:
+  - ruleset:
+      # Below is displaying it will overwrite Vela's default behavior to use a 
+      # filepath matcher and instead evaluate all rules with regex. The available
+      # matchers are: filepath, and regexp.
+      matcher: regexp
+```
+
+```yaml
+---
+steps:
+  - ruleset:
+      # Below is displaying it will overwrite Vela's default behavior to use a 
+      # "and" behavior when comparing all ruleset rules. The available
+      # operators are: and, and or.
+      operator: or
+```
+
+```yaml
+---
+steps:
+  - ruleset:
+      # Below is displaying it will is an explicit way to tell the ruleset
+      # to only execute this step when the branch is not master and event is not push.
+      unless:
+        branch: master
+        event: push
+```
+
+#### The `parameters:` tag
+
+```yaml
+---
+steps:
+    # Extra configuration variables specific to a plugin. All tags within the 
+    # parameters tag are injected environment variables into the container
+    # as PARAMETER_<TAG_NAME>. Below is illustrating a plugin that needs to fields:
+    # PARAMETERS_REGISTRY=index.docker.io
+    # PARAMETERS_REPO=octocat/hello-world,go-vela/docs
+  - parameters:
+      registry: index.docker.io
+      repo: [ go-vela/hello-world,  go-vela/docs ]
+```
+
+#### The `commands:` tag
+
+```yaml
+---
+steps:
+    # Execution instructions to run inside the container. 
+  - entrypoint:
+      - echo "Hello, World"
+```
+
+#### The `template:` tag
+
+The following tags can be used to configure a template injection:
+
+| Name   | Description                            |
+|--------| ---------------------------------------|
+| `name` | Name of template to inject in the step |
+| `vars` | Variables injected into the template   |
+
+```yaml
+---
+steps:
+  - template:
+      # Name of template to inject in the step. The name must map
+      # to an existing template in the parent "template" tag.
+      name: example
+```
+
+```yaml
+---
+steps:
+  - template:
+      # Variables injected into the template. Variables can be any
+      # primitive or complex YAML types but the corresponding template
+      # needs to understand how those templates are to be used.
+      vars:
+        tags: [ latest, "1.14", "1.15" ]
+        pull_policy: always
+        commands:
+          test: "go test ./..."
+          build: "go build ./..."  
+```
+
+#### The `entrypoint:` tag
+
+```yaml
+---
+steps:
+    # Commands to execute inside the container.
+  - entrypoint:
+      - /bin/pwd
+      - /bin/ls
+```
+
+#### The `detach:` tag
+
+```yaml
+---
+steps:
+    # Run the container in a detached (headless) state. Similar to the 
+    # "services:" tag this will create a container that can be used throughout
+    # the duration of the pipeline.
+  - detach: true
+```
+
+#### The `volume:` tag
+
+```yaml
+---
+steps:
+    # Mount volumes for the container.
+  - volume:
+      - source: /foo
+
+      - source: /foo
+        destination: /bar
+
+      - source: /foo
+        destination: /foobar
+        access_mode: ro
+```
+
+```yaml
+---
+steps:
+    # Mount volumes for the container.
+  - volume: [ /foo, /foo:/bar, /foo:/foobar:ro ]
+```
+
+#### The `ulimits:` tag
+
+```yaml
+---
+steps:
+    # Set the user limits for the container.  
+  - umlimits:
+      - name: foo
+        soft: 1024
+      - name: bar
+        soft: 1024
+        hard: 2048
+```
+
+#### The `detach:` tag
+
+```yaml
+---
+steps:
+    # Run the container with extra privileges. 
+  - privileged: true
+```

--- a/content/reference/yaml/steps.md
+++ b/content/reference/yaml/steps.md
@@ -380,7 +380,7 @@ steps:
         hard: 2048
 ```
 
-#### The `detach:` tag
+#### The `privileged:` tag
 
 ```yaml
 ---

--- a/content/reference/yaml/templates.md
+++ b/content/reference/yaml/templates.md
@@ -1,0 +1,74 @@
+---
+title: "Templates"
+linkTitle: "Templates"
+weight: 4
+description: >
+  YAML tags for templates block
+---
+
+The template tag is intended to be used to identity where to retrieve templates during the compiler phase of the pipeline.
+
+```yaml
+---
+# This document is displaying all the required tags
+# to pull a template from a remote system.
+templates:
+  - name: example
+    source: github.com/go-vela/templates/example.yml
+    type: github    
+```
+
+## Tags
+
+| Tag      | Required | Type   | Description                                           |
+|----------|----------|--------|-------------------------------------------------------|
+| `name`   | Y        | string | indicates a unique identifier for the template.       |
+| `source` | Y        | string | indicates a path to a template in remote system.      |
+| `type`   | Y        | string | indicates to the compiler which version to use.       |
+| `format` | N        | string | indicates the language used within the template file. |
+
+### Usage
+
+{{% alert title="Tip:" color="info" %}}
+To learn how to write templates, see the [template documentation](/docs/templates)
+{{% /alert %}}
+
+#### The `name:` tag
+
+```yaml
+templates:
+    # Indicates a unique identifier for the template. This identifier
+    # then can be used within a step to expand the template.
+  - name: example
+```
+
+#### The `source:` tag
+
+```yaml
+templates:
+    # Indicates a path to a template in remote system. This path
+    # should always be the raw path within a repository. By default 
+    # the template is pulled from the default branch on the repository
+    # but can be overwritten by adding "@" symbol in the path.
+    source: github.com/go-vela/templates/example.yml
+```
+
+#### The `type:` tag
+
+```yaml
+templates:
+    # Indicates to the compiler which version to use.
+    type: github
+```
+
+#### The `format:` tag
+
+```yaml
+templates:
+  - name: example
+    source: github.com/go-vela/templates/example.yml
+    type: github
+    # Indicates the language used within the template file. By default
+    # the template will be "go" but accepts the following values: go, golang, starlark
+    format: starlark
+```

--- a/content/reference/yaml/templates.md
+++ b/content/reference/yaml/templates.md
@@ -6,7 +6,7 @@ description: >
   YAML tags for templates block
 ---
 
-The template tag is intended to be used to identity where to retrieve templates during the compiler phase of the pipeline.
+The template tag is intended to be used to identify where to retrieve templates during the compiler phase of the pipeline.
 
 ```yaml
 ---

--- a/content/reference/yaml/version.md
+++ b/content/reference/yaml/version.md
@@ -1,0 +1,15 @@
+---
+title: "Version"
+linkTitle: "Version"
+weight: 1
+description: >
+  YAML tags for version block
+---
+
+The version tag is intended to be used in order to issue warnings for deprecation or breaking changes within the YAML document.
+
+```yaml
+---
+# This document is displaying using the version tag within a yaml file.
+version: "1"
+```

--- a/content/reference/yaml/version.md
+++ b/content/reference/yaml/version.md
@@ -6,7 +6,7 @@ description: >
   YAML tags for version block
 ---
 
-The version tag is intended to be used in order to issue warnings for deprecation or breaking changes within the YAML document.
+The version tag is intended to be used in order to issue warnings for deprecated features or breaking changes within the YAML document.
 
 ```yaml
 ---

--- a/content/reference/yaml/worker.md
+++ b/content/reference/yaml/worker.md
@@ -18,15 +18,15 @@ metadata:
 ```
 
 {{% alert title="Warning:" color="warning" %}}
-Routes are defined by a Vela system administrators during installation. To know what routes are available for your Vela installation, we recommend consulting your system administrators.
+Routes are defined by the Vela system administrators during installation. To know what routes are available for your Vela installation, we recommend consulting your system administrators.
 {{% /alert %}}
 
 ## Tags
 
 | Tag        | Required | Type   | Description                                          |
 |------------|----------|--------|------------------------------------------------------|
-| `flavor`   | N        | string | Indicates what flavor of worker. (i.e. sm, m, lg)    |
-| `platform` | N        | string | Indicates the platform of worker. (i.e. docker, k8s) |
+| `flavor`   | N        | string | Indicates what flavor of a worker. (i.e. sm, m, lg)    |
+| `platform` | N        | string | Indicates the platform of a worker. (i.e. docker, k8s) |
 
 ### Usage
 

--- a/content/reference/yaml/worker.md
+++ b/content/reference/yaml/worker.md
@@ -12,7 +12,7 @@ The worker tag is intended to be used to route a build to a specific worker pool
 ---
 # This document is displaying all the available tags
 # and routing the build to a specific worker "sm:docker".
-metadata:
+worker:
   flavor: sm
   platform: docker
 ```

--- a/content/reference/yaml/worker.md
+++ b/content/reference/yaml/worker.md
@@ -1,0 +1,55 @@
+---
+title: "Worker"
+linkTitle: "Worker"
+weight: 3
+description: >
+  YAML tags for worker block
+---
+
+The worker tag is intended to be used to route a build to a specific worker pool of workers available with the Vela queue.
+
+```yaml
+---
+# This document is displaying all the available tags
+# and routing the build to a specific worker "sm:docker".
+metadata:
+  flavor: sm
+  platform: docker
+```
+
+{{% alert title="Warning:" color="warning" %}}
+Routes are defined by a Vela system administrators during installation. To know what routes are available for your Vela installation, we recommend consulting your system administrators.
+{{% /alert %}}
+
+## Tags
+
+| Tag        | Required | Type   | Description                                          |
+|------------|----------|--------|------------------------------------------------------|
+| `flavor`   | N        | string | Indicates what flavor of worker. (i.e. sm, m, lg)    |
+| `platform` | N        | string | Indicates the platform of worker. (i.e. docker, k8s) |
+
+### Usage
+
+{{% alert title="Tip:" color="info" %}}
+See an [example](/docs/usage/examples/route/) on how to route a build.
+{{% /alert %}}
+
+#### The `flavor:` tag
+
+```yaml
+---
+worker:
+  # indicates what flavor of worker (i.e. sm, m, lg). If not specified
+  # will be scheduled in the generic "vela" queue.
+  flavor: sm
+```
+
+#### The `platform:` tag
+
+```yaml
+---
+worker:
+  # Indicates the platform of worker (i.e. docker, k8s). If not specified
+  # will be scheduled in the generic "vela" queue.
+  platform: docker
+```


### PR DESCRIPTION
This PR adds a new document to the YAML spec. The purpose of this section is to display and explain each tag that can be used in the YAML. The section is **intentionally** written to not be fully qualified pipelines. If users need that they should be looking at the guides/examples provided in the Usage (to be renamed Guides) tab.


The way it is written there will be some duplicate content between concepts and the new ref section. The concepts section is going to be re-imagined in a new branch coming soon. This ref section was inspired by other CI tools documentation for detailing available tags in a YAML spec. 

Inspiration:
https://docs.drone.io/yaml/docker/
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
https://circleci.com/docs/2.0/configuration-reference/#section=reference


This change will require all the YAML spec docs to point to the ref for their YAML tag. 
https://github.com/go-vela/types/blob/master/yaml/build.go#L15-L24

I will make that PR once this is merged and new links are available. 