### PR TITLE
Fix typo github to GitHub

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -13,7 +13,7 @@ linkTitle = "Veladocs"
 	</a>
 	<p class="lead mt-5">Target's official Pipeline Automation Framework</p>
 	<br>Vela is in active development and is a pre-release product. Please use at your own risk in production.<br>
-	<br>Feel free to send us feedback on <a href="https://github.com/go-vela/community/issues/new/choose">github.</a>
+	<br>Feel free to send us feedback on <a href="https://github.com/go-vela/community/issues/new/choose">GitHub</a>.
 </div>
 {{< /blocks/cover >}}
 


### PR DESCRIPTION
## What
I found a typo `github` so I've fixed it to `GitHub`.

## Why
Better documentation.
