### PR TITLE
fix: update broken links

### DIFF
--- a/content/concepts/pipeline/secrets/origin.md
+++ b/content/concepts/pipeline/secrets/origin.md
@@ -10,7 +10,7 @@ The `origin` component is a part of a [secret](/docs/concepts/pipeline/secrets/)
 This declaration allows you to pull secrets from non-internal secret providers via plugins.
 
 {{% alert color="info" %}}
-To see what plugins are supported and how they integrate with the Vela build lifecycle see the [plugins page](/docs/plugins/secrets/)
+To see what plugins are supported and how they integrate with the Vela build lifecycle see the [plugins page](/docs/plugins/registry/secret/)
 {{% /alert %}}
 
 ## Syntax

--- a/content/concepts/pipeline/worker/flavor.md
+++ b/content/concepts/pipeline/worker/flavor.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the flavor component for a worker.
 ---
 
-The `flavor` component is a part of a [template](/docs/concepts/pipeline/flavor/) for Vela.
+The `flavor` component is a part of a [template](/docs/concepts/pipeline/worker/flavor/) for Vela.
 
 This declaration allows you to route your build to a single flavors within a Vela cluster.
 

--- a/content/concepts/pipeline/worker/platform.md
+++ b/content/concepts/pipeline/worker/platform.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the platform component for a worker.
 ---
 
-The `platform` component is a part of a [template](/docs/concepts/pipeline/platform/) for Vela.
+The `platform` component is a part of a [template](/docs/concepts/pipeline/worker/platform/) for Vela.
 
 This declaration allows you to route your build to a single platform within a Vela cluster.
 

--- a/content/concepts/system/log.md
+++ b/content/concepts/system/log.md
@@ -34,4 +34,4 @@ This component is stored in the configured Vela backend in the `logs` table.
   - [Step](/docs/reference/api/step/logs/)
 - [CLI](/docs/reference/cli/log/)
 - SDK
-  - [Go](/docs/sdk/go/repo/)
+  - [Go](/docs/reference/sdk/go/)

--- a/content/reference/api/pipeline/_index.md
+++ b/content/reference/api/pipeline/_index.md
@@ -10,5 +10,5 @@ The below endpoints are available to operate on the `pipeline` resource.
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
 {{% /alert %}}

--- a/content/reference/api/pipeline/compile.md
+++ b/content/reference/api/pipeline/compile.md
@@ -41,7 +41,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/reference/api/pipeline/expand.md
+++ b/content/reference/api/pipeline/expand.md
@@ -41,7 +41,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/reference/api/pipeline/get.md
+++ b/content/reference/api/pipeline/get.md
@@ -41,7 +41,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/reference/api/pipeline/templates.md
+++ b/content/reference/api/pipeline/templates.md
@@ -41,7 +41,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/reference/api/pipeline/validate.md
+++ b/content/reference/api/pipeline/validate.md
@@ -40,7 +40,7 @@ COMING SOON!
 {{% alert color="warning" %}}
 This section assumes you already know how to authenticate to the API.
 
-To authenticate to the API, please review the [authentication documentation](/docs/api/authentication/).
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
 {{% /alert %}}
 
 #### Request

--- a/content/usage/docker.md
+++ b/content/usage/docker.md
@@ -25,7 +25,7 @@ Building an image without elevated access gives administrators the most secure p
 * [vela-kaniko](/docs/plugins/registry/pipeline/kaniko/)
 * [vela-makisu](/docs/plugins/registry/pipeline/makisu/)
 
-We recommend customers read the [tool comparisons](/docs/usage/getting-started/docker/#additional-resources) before picking a technology for building their images. In-depth examples for building with either utility are available within their respective plugin documentation pages. A simple example is provided below:
+We recommend customers read the [tool comparisons](/docs/usage/docker/#additional-resources) before picking a technology for building their images. In-depth examples for building with either utility are available within their respective plugin documentation pages. A simple example is provided below:
 
 ```yaml
 version: "1"

--- a/content/usage/environment.md
+++ b/content/usage/environment.md
@@ -21,7 +21,7 @@ The following [pipeline concepts](/docs/concepts/pipeline) are being used in the
 * [Steps](/docs/concepts/pipeline/steps/)
   * [Environment](/docs/concepts/pipeline/steps/environment/)
 * [Secrets](/docs/concepts/pipeline/secrets/)
-  * [Origin](/docs/concepts/pipeline/steps/origin/)
+  * [Origin](/docs/concepts/pipeline/secrets/origin/)
 
 {{% alert title="Note:" color="primary" %}}
 Please be warned that `${variable}` expressions are subject to pre-processing.

--- a/content/usage/examples/go_modules.md
+++ b/content/usage/examples/go_modules.md
@@ -65,7 +65,7 @@ steps:
 The following [pipeline concepts](/docs/concepts/pipeline) are being used in the pipeline below:
 
 * [Stages](/docs/concepts/pipeline/stages/)
-  * [Needs](/docs/concepts/pipeline/needs/)
+  * [Needs](/docs/concepts/pipeline/stages/needs/)
   * [Steps](/docs/concepts/pipeline/steps/)
     * [image](/docs/concepts/pipeline/steps/image/)
     * [Environment](/docs/concepts/pipeline/steps/environment/)

--- a/content/usage/examples/java_maven.md
+++ b/content/usage/examples/java_maven.md
@@ -55,7 +55,7 @@ steps:
 The following [pipeline concepts](/docs/concepts/pipeline) are being used in the pipeline below:
 
 * [Stages](/docs/concepts/pipeline/stages/)
-  * [Needs](/docs/concepts/pipeline/needs/)
+  * [Needs](/docs/concepts/pipeline/stages/needs/)
   * [Steps](/docs/concepts/pipeline/steps/)
     * [image](/docs/concepts/pipeline/steps/image/)
     * [Pull](/docs/concepts/pipeline/steps/pull/)

--- a/content/usage/examples/node.md
+++ b/content/usage/examples/node.md
@@ -55,7 +55,7 @@ steps:
 The following [pipeline concepts](/docs/concepts/pipeline) are being used in the pipeline below:
 
 * [Stages](/docs/concepts/pipeline/stages/)
-  * [Needs](/docs/concepts/pipeline/needs/)
+  * [Needs](/docs/concepts/pipeline/stages/needs/)
   * [Steps](/docs/concepts/pipeline/steps/)
     * [image](/docs/concepts/pipeline/steps/image/)
     * [Pull](/docs/concepts/pipeline/steps/pull/)

--- a/content/usage/examples/route.md
+++ b/content/usage/examples/route.md
@@ -21,7 +21,7 @@ Work with your server administer to understand what routes are available for you
 The following [pipeline concepts](/docs/concepts/pipeline) are being used in the pipeline below:
 
 * [Worker](/docs/concepts/pipeline/worker/)
-  * [Runtime](/docs/concepts/pipeline/worker/runtime/)
+  * [Platform](/docs/concepts/pipeline/worker/platform/)
 * [Steps](/docs/concepts/pipeline/steps/)
   * [Image](/docs/concepts/pipeline/steps/image/)
   * [Pull](/docs/concepts/pipeline/steps/pull/)
@@ -37,7 +37,7 @@ It is recommended to pin `image:` versions for production pipelines
 version: "1"
 
 worker:
-  runtime: docker
+  platform: docker
 
 steps:
   - name: view worker name
@@ -52,7 +52,7 @@ steps:
 The following [pipeline concepts](/docs/concepts/pipeline) are being used in the pipeline below:
 
 * [Worker](/docs/concepts/pipeline/worker/)
-  * [Runtime](/docs/concepts/pipeline/worker/runtime/)
+  * [Platform](/docs/concepts/pipeline/worker/platform/)
 * [Stages](/docs/concepts/pipeline/stages/)
   * [Steps](/docs/concepts/pipeline/steps/)
   * [Image](/docs/concepts/pipeline/steps/image/)
@@ -70,7 +70,7 @@ It is recommended to pin `image:` versions for production pipelines
 version: "1"
 
 worker:
-  runtime: docker
+  platform: docker
 
 stages:
   docker:

--- a/content/usage/examples/rust_cargo.md
+++ b/content/usage/examples/rust_cargo.md
@@ -61,7 +61,7 @@ steps:
 The following [pipeline concepts](/docs/concepts/pipeline) are being used in the pipeline below:
 
 * [Stages](/docs/concepts/pipeline/stages/)
-  * [Needs](/docs/concepts/pipeline/needs/)
+  * [Needs](/docs/concepts/pipeline/stages/needs/)
   * [Steps](/docs/concepts/pipeline/steps/)
     * [image](/docs/concepts/pipeline/steps/image/)
     * [Pull](/docs/concepts/pipeline/steps/pull/)

--- a/content/usage/examples/secrets_external.md
+++ b/content/usage/examples/secrets_external.md
@@ -31,7 +31,7 @@ The following [pipeline concepts](/docs/concepts/pipeline) are being used in the
 
 The following [Vela plugins](/docs/concepts/pipeline) are being used in the pipeline below:
 
-* [Docker](/docs/plugins/pipeline/registry/docker/)
+* [Docker](/docs/plugins/registry/pipeline/docker/)
 
 {{% alert title="Note:" color="primary" %}}
 Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`
@@ -83,7 +83,7 @@ The following [pipeline concepts](/docs/concepts/pipeline) are being used in the
 
 The following [Vela plugins](/docs/concepts/pipeline) are being used in the pipeline below:
 
-* [Docker](/docs/plugins/pipeline/registry/docker/)
+* [Docker](/docs/plugins/registry/pipeline/docker/)
 
 {{% alert title="Note:" color="primary" %}}
 Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`

--- a/content/usage/examples/secrets_internal.md
+++ b/content/usage/examples/secrets_internal.md
@@ -31,7 +31,7 @@ The following [pipeline concepts](/docs/concepts/pipeline) are being used in the
 
 The following [Vela plugins](/docs/concepts/pipeline) are being used in the pipeline below:
 
-* [Docker](/docs/plugins/pipeline/registry/docker/)
+* [Docker](/docs/plugins/registry/pipeline/docker/)
 
 {{% alert title="Note:" color="primary" %}}
 Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`
@@ -77,7 +77,7 @@ The following [pipeline concepts](/docs/concepts/pipeline) are being used in the
 
 The following [Vela plugins](/docs/concepts/pipeline) are being used in the pipeline below:
 
-* [Docker](/docs/plugins/pipeline/registry/docker/)
+* [Docker](/docs/plugins/registry/pipeline/docker/)
 
 {{% alert title="Note:" color="primary" %}}
 Pipeline must be stored in base of repository as `.vela.yml` or `.vela.yaml`

--- a/content/usage/pull_policies.md
+++ b/content/usage/pull_policies.md
@@ -16,7 +16,7 @@ The following [pipeline concepts](/docs/concepts/pipeline) are being used in the
 * [Steps](/docs/concepts/pipeline/steps/)
   * [Pull](/docs/concepts/pipeline/steps/pull/)
 * [Secrets](/docs/concepts/pipeline/secrets/)
-  * [Origin](/docs/concepts/pipeline/steps/origin/)
+  * [Origin](/docs/concepts/pipeline/secrets/origin/)
 
 {{% alert title="Note:" color="primary" %}}
 Please be warned that the `pull` declaration is **not required**.

--- a/content/usage/start_build.md
+++ b/content/usage/start_build.md
@@ -5,6 +5,6 @@ description: >
   Start a build for the first time.
 ---
 
-If you've followed the documentation for [enabling a repo](/docs/usage/getting-started/enable_repo/) and [writing a pipeline](/docs/usage/getting-started/write_pipeline/), all that should be left is to push your pipeline to your repo.
+If you've followed the documentation for [enabling a repo](/docs/usage/enable_repo/) and [writing a pipeline](/docs/usage/write_pipeline/), all that should be left is to push your pipeline to your repo.
 
 If a build does not trigger when your push a change to your repo, check the webhook response to see if there is an error.


### PR DESCRIPTION
Based on a script's output for what links were broken, I went through and updated broken links. Most were just path changes (e.g. removing the `getting-started` path when we flattened docs awhile ago)

QUESTION:
I was unable to find the page that goes with /docs/usage/getting-started/write_pipeline/ on [this page](https://github.com/go-vela/docs/blob/master/content/usage/start_build.md) - does anyone know what it should be?

