### PR TITLE
Update default value for "pull" tag

### DIFF
--- a/content/reference/yaml/steps.md
+++ b/content/reference/yaml/steps.md
@@ -65,8 +65,8 @@ steps:
 ---
 steps:
     # Declaration to configure if and when the Docker image is pulled.
-    # By default, the compiler will inject pull but accepts the 
-    # following values: always, never, no_present, on_start, 
+    # By default, the compiler will inject pull with value not_present but
+    # accepts the following values: always, never, not_present, on_start
   - pull: always
 ```
 


### PR DESCRIPTION
I found here https://go-vela.github.io/docs/concepts/pipeline/steps/pull/ that the default value for this was not_present but did not verify in the code.

Also corrected a typo with no_present missing a t