### PR TITLE
docs(templates): remove warning about secrets and services

### DIFF
--- a/content/templates/_index.md
+++ b/content/templates/_index.md
@@ -16,8 +16,6 @@ Templates can take the form of generalized workflows across repositories or comp
 {{% alert color="warning" %}}
 The following YAML tags are not valid inside a template pipeline:
 
-* `services:`
-* `secrets:`
 * `stages:`
 * `templates:`
 {{% /alert %}}


### PR DESCRIPTION
Should wait to be merged until 0.8.0 is officially released.

xref: https://github.com/go-vela/community/issues/195 https://github.com/go-vela/community/issues/194