### PR TITLE
feat: add additional deployment info

### DIFF
--- a/content/reference/cli/deployment/add.md
+++ b/content/reference/cli/deployment/add.md
@@ -19,15 +19,16 @@ For more information, you can run `vela add deployment --help`.
 
 The following parameters are used to configure the command:
 
-| Name          | Description                                       | Environment Variables                        |
-| ------------- | ------------------------------------------------- | -------------------------------------------- |
-| `org`         | name of organization for the deployment           | `VELA_ORG`, `DEPLOYMENT_ORG`                 |
-| `repo`        | name of repository for the deployment             | `VELA_REPO`, `DEPLOYMENT_REPO`               |
-| `ref`         | name of branch, commit, or tag for the deployment | `VELA_DEPLOYMENT`, `DEPLOYMENT_NUMBER`       |
-| `target`      | name of target environment for the deployment     | `VELA_TARGET`, `DEPLOYMENT_TARGET`           |
-| `description` | short description for the deployment              | `VELA_DESCRIPTION`, `DEPLOYMENT_DESCRIPTION` |
-| `task`        | name of task for the deployment                   | `VELA_TASK`, `DEPLOYMENT_TASK`               |
-| `output`      | format the output for the deployment              | `VELA_OUTPUT`, `DEPLOYMENT_OUTPUT`           |
+| Name          | Description                                         | Environment Variables                        |
+| ------------- | --------------------------------------------------- | -------------------------------------------- |
+| `org`         | name of organization for the deployment             | `VELA_ORG`, `DEPLOYMENT_ORG`                 |
+| `repo`        | name of repository for the deployment               | `VELA_REPO`, `DEPLOYMENT_REPO`               |
+| `ref`         | name of branch, commit, or tag for the deployment   | `VELA_DEPLOYMENT`, `DEPLOYMENT_NUMBER`       |
+| `target`      | name of target environment for the deployment       | `VELA_TARGET`, `DEPLOYMENT_TARGET`           |
+| `description` | short description for the deployment                | `VELA_DESCRIPTION`, `DEPLOYMENT_DESCRIPTION` |
+| `parameter`   | parameter(s) in key=value format for the deployment | `VELA_PARAMETERS,`, `DEPLOYMENT_PARAMETERS`  |
+| `task`        | name of task for the deployment                     | `VELA_TASK`, `DEPLOYMENT_TASK`               |
+| `output`      | format the output for the deployment                | `VELA_OUTPUT`, `DEPLOYMENT_OUTPUT`           |
 
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
@@ -39,10 +40,6 @@ This command also supports setting the following parameters via a configuration 
 For more information, please review the [CLI config documentation](/docs/reference/cli/config/).
 {{% /alert %}}
 
-## Permissions
-
-COMING SOON!
-
 ## Sample
 
 {{% alert color="warning" %}}
@@ -53,14 +50,30 @@ To install the CLI, please review the [installation documentation](/docs/referen
 To setup the CLI, please review the [authentication documentation](/docs/reference/cli/authentication/).
 {{% /alert %}}
 
-#### Request
-
 ```sh
-vela add deployment --org github --repo octocat
+# Request with CLI to add a deployment for the "github" org and "octocat" repo
+$ vela add deployment --org github --repo octocat
+
+# Response generated from successful CLI command
+deployment "https://api.github.com/repos/github/octocat/deployments/1" was created
 ```
 
-#### Response
+## Examples
 
 ```sh
-deployment "https://api.github.com/repos/github/octocat/deployments/1" was created
+EXAMPLES:
+  1. Add a deployment for a repository.
+    $ vela add deployment --org MyOrg --repo MyRepo
+  2. Add a deployment for a repository with a specific target environment.
+    $ vela add deployment --org MyOrg --repo MyRepo --target stage
+  3. Add a deployment for a repository with a specific branch reference.
+    $ vela add deployment --org MyOrg --repo MyRepo --ref dev
+  4. Add a deployment for a repository with a specific commit reference.
+    $ vela add deployment --org MyOrg --repo MyRepo --ref 48afb5bdc41ad69bf22588491333f7cf71135163
+  5. Add a deployment for a repository with a specific description.
+    $ vela add deployment --org MyOrg --repo MyRepo --description 'my custom message'
+  6. Add a deployment for a repository with two parameters.
+    $ vela add deployment --org MyOrg --repo MyRepo --parameter 'key=value' --parameter 'foo=bar'
+  7. Add a deployment for a repository when config or environment variables are set.
+    $ vela add deployment
 ```

--- a/content/reference/cli/deployment/get.md
+++ b/content/reference/cli/deployment/get.md
@@ -37,10 +37,6 @@ This command also supports setting the following parameters via a configuration 
 For more information, please review the [CLI config documentation](/docs/reference/cli/config/).
 {{% /alert %}}
 
-## Permissions
-
-COMING SOON!
-
 ## Sample
 
 {{% alert color="warning" %}}
@@ -51,16 +47,28 @@ To install the CLI, please review the [installation documentation](/docs/referen
 To setup the CLI, please review the [authentication documentation](/docs/reference/cli/authentication/).
 {{% /alert %}}
 
-#### Request
-
 ```sh
-vela get deployment --org github --repo octocat
-```
+# Request with CLI to view a deployment for the "github" org and "octocat" repo
+$ vela get deployment --org github --repo octocat
 
-#### Response
-
-```sh
+# Response generated from successful CLI command
 ID  TASK         USER     REF     TARGET
 2   deploy:vela  octocat  master  production
 1   deploy:vela  octocat  master  production
+```
+
+## Examples
+
+```sh
+EXAMPLES:
+  1. Get deployments for a repository.
+    $ vela get deployment --org MyOrg --repo MyRepo
+  2. Get deployments for a repository with wide view output.
+    $ vela get deployment --org MyOrg --repo MyRepo --output wide
+  3. Get deployments for a repository with yaml output.
+    $ vela get deployment --org MyOrg --repo MyRepo --output yaml
+  4. Get deployments for a repository with json output.
+    $ vela get deployment --org MyOrg --repo MyRepo --output json
+  5. Get deployments for a repository when config or environment variables are set.
+    $ vela get deployment
 ```

--- a/content/reference/cli/deployment/view.md
+++ b/content/reference/cli/deployment/view.md
@@ -36,10 +36,6 @@ This command also supports setting the following parameters via a configuration 
 For more information, please review the [CLI config documentation](/docs/reference/cli/config/).
 {{% /alert %}}
 
-## Permissions
-
-COMING SOON!
-
 ## Sample
 
 {{% alert color="warning" %}}
@@ -50,15 +46,11 @@ To install the CLI, please review the [installation documentation](/docs/referen
 To setup the CLI, please review the [authentication documentation](/docs/reference/cli/authentication/).
 {{% /alert %}}
 
-#### Request
-
 ```sh
-vela view deployment --org github --repo octocat --deployment 1
-```
+# Request with CLI to add a deployment for the "github" org and "octocat" repo
+$ vela view deployment --org github --repo octocat --deployment 1
 
-#### Response
-
-```sh
+# Response generated from successful CLI command
 id: 1
 repo_id: 1
 url: https://api.github.com/repos/github/octocat/deployments/1
@@ -68,4 +60,16 @@ ref: master
 task: deploy:vela
 target: production
 description: Deployment request from Vela
+```
+
+## Examples
+
+```sh
+EXAMPLES:
+  1. View deployment details for a repository.
+    $ vela view deployment --org MyOrg --repo MyRepo --deployment 1
+  2. View deployment details for a repository with json output.
+    $ vela view deployment --org MyOrg --repo MyRepo --deployment 1 --output json
+  3. View deployment details for a repository config or environment variables are set.
+    $ vela view deployment --deployment 1
 ```

--- a/content/reference/environment/variables.md
+++ b/content/reference/environment/variables.md
@@ -38,8 +38,10 @@ The following environment variables are injected into every step, service, or se
 | `VELA_BUILD_TITLE`        | `push received from https://github.com/octocat/hello-world` | title for the build                                                 |
 | `VELA_BUILD_WORKSPACE`    | `/vela/src/github.com/octocat/hello-world`                  | working directory the build is executed in                          |
 
+##### `comment` event only
+
 {{% alert color="info" %}}
-The following table includes variables only available during the **comment** event
+The following table includes variables only available during the **comment** event.
 {{% /alert %}}
 
 | Key                       | Value | Explanation                                                |
@@ -47,8 +49,12 @@ The following table includes variables only available during the **comment** eve
 | `VELA_BUILD_PULL_REQUEST` | `1`   | pull request number is populated from the source reference |
 | `VELA_PULL_REQUEST`       | `1`   | pull request number is populated from the source reference |
 
+##### `deployment` event only
+
 {{% alert color="info" %}}
-The following table includes variables only available during the **deploy** event
+The following table includes variables only available during the **deployment** event.
+
+All custom parameters are passed are available with a `DEPLOYMENT_PARAMETER_` prefix of the key.
 {{% /alert %}}
 
 | Key                 | Value        | Explanation                                   |
@@ -56,8 +62,10 @@ The following table includes variables only available during the **deploy** even
 | `VELA_BUILD_TARGET` | `production` | name of target environment for the deployment |
 | `VELA_DEPLOYMENT`   | `production` | name of target environment for the deployment |
 
+##### `pull_request` event only
+
 {{% alert color="info" %}}
-The following table includes variables only available during the **pull request** event
+The following table includes variables only available during the **pull_request** event.
 {{% /alert %}}
 
 | Key                        | Value    | Explanation                                                |
@@ -67,8 +75,10 @@ The following table includes variables only available during the **pull request*
 | `VELA_PULL_REQUEST_SOURCE` | `dev`    | pull request branch from the source reference              |
 | `VELA_PULL_REQUEST_TARGET` | `master` | pull request branch for the target reference               |
 
+##### `tag` event only
+
 {{% alert color="info" %}}
-The following table includes variables only available during the **tag** event
+The following table includes variables only available during the **tag** event.
 {{% /alert %}}
 
 | Key              | Value    | Explanation                                |

--- a/content/reference/environment/variables.md
+++ b/content/reference/environment/variables.md
@@ -54,7 +54,7 @@ The following table includes variables only available during the **comment** eve
 {{% alert color="info" %}}
 The following table includes variables only available during the **deployment** event.
 
-All custom parameters are passed are available with a `DEPLOYMENT_PARAMETER_` prefix of the key.
+All custom parameters are passed to the deployment available with a `DEPLOYMENT_PARAMETER_` prefix of the key.
 {{% /alert %}}
 
 | Key                 | Value        | Explanation                                   |

--- a/content/usage/deployments.md
+++ b/content/usage/deployments.md
@@ -1,0 +1,91 @@
+---
+title: "Managing Deployments"
+toc: true
+description: >
+  Learn about how to leverage deployments for your builds
+---
+
+Pipelines can be written with your specific branching methodology in mind but when it comes to deployments you often want to be very intentional with triggering a change. For this reason, Vela has deployments, a unique build event that is triggered directly via Vela on a specific ref (branch, SHA, tag).
+
+Vela leverages a deep integration with [GitHub Deployments](https://docs.github.com/en/rest/reference/repos#deployments) which will not only trigger your build but create a system of record on GitHub for your deployment action. You can leverage a deployment in your steps like:
+
+{{% alert title="Tip:" color="info" %}}
+Make sure you have events enabled on your repo and any secrets are available for that event.
+{{% /alert %}}
+
+```yaml
+# A step triggering on "all" deployment events
+- name: All deployments
+  image: alpine
+  commands:
+    - echo "Running your deployment!"
+  ruleset:
+    events: [ deployment ]
+
+# A step triggering deployment to a specific target.
+# Targets can be any value i.e. dev, stage, eng, prod, etc
+- name: Targeted deployments
+  image: alpine
+  commands:
+    - echo "Running deployment for ${VELA_DEPLOYMENT}!"
+  ruleset:
+    events: [ deployment ]
+    target: [ dev, eng ]
+```
+
+## Usage
+
+Let us look at an example workflow for executing a deployment on your repo. You should understand the following concepts before proceeding:
+
+* [Steps](/docs/tour/steps/)
+  * [image](/docs/tour/image/)
+  * [Commands](/docs/tour/environment/)
+  * [Ruleset](/docs/tour/ruleset/)
+
+```yaml
+version: "1"
+steps:
+  # A step triggering on "all" deployment events
+  - name: All deployments
+    image: alpine
+    commands:
+      - echo "Running your deployment!"
+    ruleset:
+      events: [ deployment ]
+
+  # A step triggering deployment to a specific target.
+  # Targets can be any value i.e. dev, stage, eng, prod, etc
+  - name: Targeted deployments
+    image: alpine
+    commands:
+      - echo "Running deployment for ${VELA_DEPLOYMENT}!"
+    ruleset:
+      events: [ deployment ]
+      target: [ dev, eng ]
+
+  # Now that we know how to control a deployment, lets look
+  # at adding custom parameters. Sometimes not only do you need
+  # control of the target but you want custom data available
+  # when your pipeline runs.
+  - name: Custom parameters deployments
+    image: alpine
+    commands:
+      - echo "Custom parameter message, ${DEPLOYMENT_PARAMETER_MESSAGE}"
+    ruleset:
+      events: [ deployment ]
+      target: [ dev, eng ]
+```
+
+The following CLI commands will trigger the pipeline and produce different permutations of the pipeline executing:
+
+```sh
+# Trigger deployment with no additional configuration
+$ vela add deployment --org github --repo octocat
+
+# Trigger deployment for a repository with a specific target environment.
+$ vela add deployment --org github --repo octocat --target stage
+
+# Add a deployment for a repository with two parameters.
+$ vela add deployment --org github --repo octocat --parameter 'message=Hello, custom var!'
+```
+

--- a/content/usage/deployments.md
+++ b/content/usage/deployments.md
@@ -10,7 +10,9 @@ Pipelines can be written with your specific branching methodology in mind but wh
 Vela leverages a deep integration with [GitHub Deployments](https://docs.github.com/en/rest/reference/repos#deployments) which will not only trigger your build but create a system of record on GitHub for your deployment action. You can leverage a deployment in your steps like:
 
 {{% alert title="Tip:" color="info" %}}
-Make sure you have events enabled on your repo and any secrets are available for that event.
+Make sure you have the `deployment` event enabled within repo settings
+
+ Additionally, any secret you may need for the event must also have `deployments` allowed for events.
 {{% /alert %}}
 
 ```yaml


### PR DESCRIPTION
PR includes the following changes:

* Adds a new example page within the usage section
* Updates environment information with info about deployments and pins to content
* Updates refreshes CLI docs with the accurate flags/info in the binaries

_Note: PR does include the proper tour links for compatibility with that [branch](https://github.com/go-vela/docs/pull/207)._


closes: https://github.com/go-vela/community/issues/210