### PR TITLE
chore: link updates

### DIFF
--- a/content/concepts/pipeline/secrets/origin.md
+++ b/content/concepts/pipeline/secrets/origin.md
@@ -5,7 +5,7 @@ description: >
   This section contains information on the origin component for a secret.
 ---
 
-The `origin` component is a part of a [secret](/docs/concepts/pipeline/secrets/) for Vela.
+The `origin` component is a part of a [secret](/docs/tour/secrets/) for Vela.
 
 This declaration allows you to pull secrets from non-internal secret providers via plugins.
 

--- a/content/usage/deployments.md
+++ b/content/usage/deployments.md
@@ -42,7 +42,7 @@ Let us look at an example workflow for executing a deployment on your repo. You 
 * [Steps](/docs/tour/steps/)
   * [image](/docs/tour/image/)
   * [Commands](/docs/tour/environment/)
-  * [Ruleset](/docs/tour/ruleset/)
+  * [Ruleset](/docs/tour/rulesets/)
 
 ```yaml
 version: "1"

--- a/content/usage/examples/route.md
+++ b/content/usage/examples/route.md
@@ -20,8 +20,8 @@ Work with your server administer to understand what routes are available for you
 
 The following [pipeline concepts](/docs/tour/) are being used in the pipeline below:
 
-* [Worker](/docs/tour/worker/)
-  * [Platform](/docs/tour/worker/)
+* *Worker* 
+  * *Platform* 
 * [Steps](/docs/tour/steps/)
   * [Image](/docs/tour/image/)
   * [Pull](/docs/tour/image/)


### PR DESCRIPTION
more link updates, but notable removes the links from here:

```
* [Worker](/docs/tour/worker/)
  * [Platform](/docs/tour/worker/)
 ```

since there isn't a good place to direct them too.