### PR TITLE
feat: add environment tag for global injection

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -5,7 +5,7 @@ linkTitle = "Veladocs"
 
 {{< blocks/cover title="Welcome to Vela!" image_anchor="bottom" height="min" width="primary">}}
 <div class="mx-auto">
-	<a class="btn btn-lg btn-primary -lavender mr-3 mb-4" href="{{< relref "/usage" >}}">
+	<a class="btn btn-lg btn-primary -lavender mr-3 mb-4" href="{{< relref "/tour" >}}">
 		Learn More <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
 	<a class="btn btn-lg btn-secondary -lavender mr-3 mb-4" href="https://github.com/go-vela">

--- a/content/reference/yaml/environment.md
+++ b/content/reference/yaml/environment.md
@@ -1,0 +1,18 @@
+---
+title: "Environment"
+linkTitle: "Environment"
+weight: 1
+description: >
+  YAML tags for environment block
+---
+
+The environment tag is intended to be used to inject a global environment configuration into steps, services and secret containers. Control of which container types get the injected environment settings is available via the metadata block.
+
+```yaml
+---
+# This document is displaying using the environment tag with a map syntax.
+# Additionally, you can also use array syntax where the items in
+# they array are of pattern HELLO="Hello, Vela!"
+environment:
+  HELLO: "Hello, Vela!"
+```

--- a/content/reference/yaml/metadata.md
+++ b/content/reference/yaml/metadata.md
@@ -55,8 +55,8 @@ metadata:
 ```yaml
 ---
 metadata:
-  # By default, the below is populated into every pipeline
-  # but if block exists configuration specified is used during
-  # environment injection during compile phase
+  # By default, the below is populated into every pipeline with
+  # services, steps, and secrets. But, when the block exists the
+  # configuration specified is used during compile phase.
   environment: [ steps, services, secrets ]
 ```

--- a/content/reference/yaml/metadata.md
+++ b/content/reference/yaml/metadata.md
@@ -49,3 +49,14 @@ metadata:
   # Enables injecting the default clone process
   clone: true
 ```
+
+#### The `environment:` tag
+
+```yaml
+---
+metadata:
+  # By default, the below is populated into every pipeline
+  # but if block exists configuration specified is used during
+  # environment injection during compile phase
+  environment: [ steps, services, secrets ]
+```

--- a/content/usage/environment.md
+++ b/content/usage/environment.md
@@ -5,9 +5,9 @@ description: >
   Learn about how to leverage the environment within your builds.
 ---
 
-Vela provides the ability to define environment variables scoped to individual steps, services and secrets. Additionally, if you need global environment setting you can set it at the parent and have it injected to all containers.
+Vela provides the ability to define environment variables scoped to individual steps, services and secrets. Additionally, if you need global environment variables you can set it at the parent and have it injected to all containers.
 
-Please note the environment is design to be unique per container. Vela does inject a variety of default values from build, repo and user information.
+Please note the environment is designed to be unique per container. Vela does inject a variety of default values from build, repo and user information.
 
 Defaults:
 
@@ -71,7 +71,7 @@ secrets:
 
 ## Global Usage
 
-By default global injection effects all containers ran within the pipeline but if only want some container types to receive the configuration you can limit which types get them by adding the `environment` declaring into the metadata.
+By default global injection affects all containers ran within the pipeline. However, if only want some container types to receive the configuration you can limit which types get them by adding the `environment` declaration into the metadata.
 
 {{% alert title="Note:" color="primary" %}}
 Valid values for metadata `environment:` YAML tag are `steps`, `services` and `secrets`.
@@ -98,13 +98,14 @@ steps:
 +   environment:
 +     LOCAL_EXAMPLE: Hello, World!
     commands:
-      # you can use bash commands in-line to set or override variables
+      # you can local shell commands in-line to set or override variables
       - export EXAMPLE="Hello World From Vela Team"
       - echo ${EXAMPLE}
       - echo ${GLOBAL_EXAMPLE}
 
 secrets:
-  # Global configuration is no longer available in secrets
+  # Global configuration is no longer available in secrets since "secrets"
+  # was removed as a value in the metadata.environment block.
   - origin:
       name: private vault
       image: target/secret-vault:latest


### PR DESCRIPTION
PR Includes the following changes:

- adds new global environment example to usage
- adds new global environment setting on pipeline
- adds new global environment control setting on metadata

_Story for additionally context https://github.com/go-vela/community/issues/304_