### PR TITLE
Add link to templates YAML reference documentation

### DIFF
--- a/content/templates/_index.md
+++ b/content/templates/_index.md
@@ -22,7 +22,7 @@ The following YAML tags are not valid inside a template pipeline:
 
 ## Reference documentation
 
-Check out the [YAML reference documentation](https://go-vela.github.io/docs/reference/yaml/templates/) for templates.
+Check out the [YAML reference documentation](/docs/reference/yaml/templates/) for templates.
 
 ## Template Engines
 

--- a/content/templates/_index.md
+++ b/content/templates/_index.md
@@ -20,6 +20,10 @@ The following YAML tags are not valid inside a template pipeline:
 * `templates:`
 {{% /alert %}}
 
+## Reference documentation
+
+Check out the [YAML reference documentation](https://go-vela.github.io/docs/reference/yaml/templates/) for templates.
+
 ## Template Engines
 
 ### Format


### PR DESCRIPTION
Make the reference documentation more discoverable to
people searching for information about Vela templates.

On the heels of #237 