### PR TITLE
feat(plugins): add influx pipeline plugin

### DIFF
--- a/content/plugins/registry/pipeline/influx.md
+++ b/content/plugins/registry/pipeline/influx.md
@@ -1,0 +1,5 @@
+---
+title: "Influx"
+---
+
+{{% plugin-docs "vela-influx" %}}


### PR DESCRIPTION
This adds docs for the Vela Influx plugin:

https://github.com/go-vela/vela-influx

The docs should be fetched directly from:

https://github.com/go-vela/vela-influx/blob/main/DOCS.md