### PR TITLE
feat(plugins): add hugo pipeline plugin

### DIFF
--- a/content/plugins/registry/pipeline/hugo.md
+++ b/content/plugins/registry/pipeline/hugo.md
@@ -1,0 +1,5 @@
+---
+title: "Hugo"
+---
+
+{{% plugin-docs "vela-hugo" %}}


### PR DESCRIPTION
This adds docs for the Vela Hugo plugin:

https://github.com/go-vela/vela-hugo

The docs should be fetched directly from:

https://github.com/go-vela/vela-hugo/blob/main/DOCS.md