### PR TITLE
feat(plugins): add build-summary pipeline plugin

### DIFF
--- a/content/plugins/registry/pipeline/build-summary.md
+++ b/content/plugins/registry/pipeline/build-summary.md
@@ -1,0 +1,5 @@
+---
+title: "Build Summary"
+---
+
+{{% plugin-docs "vela-build-summary" %}}


### PR DESCRIPTION
This adds docs for the Vela Build Summary plugin:

https://github.com/go-vela/vela-build-summary

The docs should be fetched directly from:

https://github.com/go-vela/vela-build-summary/blob/main/DOCS.md