### PR TITLE
feat(plugins): add slack pipeline plugin

### DIFF
--- a/content/plugins/registry/pipeline/slack.md
+++ b/content/plugins/registry/pipeline/slack.md
@@ -1,0 +1,5 @@
+---
+title: "Slack"
+---
+
+{{% plugin-docs "vela-slack" %}}


### PR DESCRIPTION
This adds docs for the Vela Slack plugin:

https://github.com/go-vela/vela-slack

The docs should be fetched directly from:

https://github.com/go-vela/vela-slack/blob/main/DOCS.md