### PR TITLE
fix: removing outdated links and updating moved pages

### DIFF
--- a/content/concepts/pipeline/secrets/origin.md
+++ b/content/concepts/pipeline/secrets/origin.md
@@ -49,5 +49,5 @@ steps:
 ```
 
 {{% alert color="info" %}}
-To see more information on the Vault plugin usage see the [Vault docs](docs/plugins/registry/secret/vault)
+To see more information on the Vault plugin usage see the [Vault docs](/docs/plugins/registry/secret/vault)
 {{% /alert %}}

--- a/content/usage/examples/route.md
+++ b/content/usage/examples/route.md
@@ -20,8 +20,8 @@ Work with your server administer to understand what routes are available for you
 
 The following [pipeline concepts](/docs/tour/) are being used in the pipeline below:
 
-* *Worker* 
-  * *Platform* 
+* *Worker*
+  * *Platform*
 * [Steps](/docs/tour/steps/)
   * [Image](/docs/tour/image/)
   * [Pull](/docs/tour/image/)
@@ -51,8 +51,8 @@ steps:
 
 The following [pipeline concepts](/docs/tour/) are being used in the pipeline below:
 
-* [Worker](/docs/tour/worker/)
-  * [Platform](/docs/tour/worker/)
+* *Worker*
+  * *Platform*
 * [Stages](/docs/tour/stages/)
   * [Steps](/docs/tour/steps/)
   * [Image](/docs/tour/image/)


### PR DESCRIPTION
There were a couple of references to broken links or things that had gotten missed while moving documentation around. This is just a small PR to address those broken links.

# Validation
These were found using @davidvader's initial testing with linkinator.
Command executed against production site below. I'm skipping anything mentioning a docker location, github.com links (for the edit this page links) and the favicon.
```sh
npx linkinator --verbosity error --skip docker.,github.com,favicon -r https://go-vela.github.io/docs/
```
And if you're testing locally
```sh
npx linkinator --verbosity error --skip docker.,github.com,favicon -r http://localhost:1313/docs/
```