### PR TITLE
docs(secrets)!:removed references to implicit secrets

### DIFF
--- a/content/concepts/pipeline/secrets/origin.md
+++ b/content/concepts/pipeline/secrets/origin.md
@@ -24,8 +24,10 @@ metadata:
   template: false
 
 secrets:
-  # Implicit secret definition.
   - name: vault_token
+    key: go-vela/vault_token
+    engine: native
+    type: org
 
 +  - origin:
 +     name: vault external secrets

--- a/content/plugins/_index.md
+++ b/content/plugins/_index.md
@@ -37,7 +37,7 @@ These actions can be for any number of general tasks, including:
 
 ### Example
 
-The example we have shown is publishing an image to a registry. Pipeline plugins configuration works via environment variables that pass data from pipeline to the container at runtime. 
+The example we have shown is publishing an image to a registry. Pipeline plugins configuration works via environment variables that pass data from pipeline to the container at runtime.
 
 _Not a runnable pipeline_
 ```diff
@@ -58,7 +58,7 @@ steps:
 Secret plugins are configured with an allow list of available images via an administator on installation. To know which secret plugins are available for your Vela installation, we recommend consulting your system administrators.
 {{% /alert %}}
 
-Secret plugins are designed to be used to read secrets in volumes within the Vela workspace. When a secret plugin runs the plugin should write data to the custom Vela mount (`/vela/secrets/`) as key/value pairs. Secret plugins configuration works via environment variables that pass data from pipeline to the container at runtime. 
+Secret plugins are designed to be used to read secrets in volumes within the Vela workspace. When a secret plugin runs the plugin should write data to the custom Vela mount (`/vela/secrets/`) as key/value pairs. Secret plugins configuration works via environment variables that pass data from pipeline to the container at runtime.
 
 A secret plugin works in tandem with the Vela workspace to read data from a provider and write them into an available location (`/vela/secrets`) within a pipeline.
 
@@ -68,6 +68,9 @@ _Not a runnable pipeline_
 ```diff
 secrets:
   - name: vault_token
+    key: go-vela/vault_token
+    engine: native
+    type: org
 
   - origin:
       name: vault
@@ -80,7 +83,7 @@ secrets:
 +       username: octocat
 +       items:
 +         - source: secret/docker
-+           path: docker  
++           path: docker
 ```
 
 From the above example, will have written the following available secrets to:

--- a/content/reference/yaml/secrets.md
+++ b/content/reference/yaml/secrets.md
@@ -11,12 +11,8 @@ The secret tag is intended to be used to pull secrets from the Vela server or ex
 ```yaml
 ---
 # This document is displaying all the required tags
-# to pull various secret types. 
-secrets: 
-  # Below is displaying the implicit native secret definition. This definition 
-  # is only supported for native secrets of repository type.
-  - name: foo
-
+# to pull various secret types.
+secrets:
   # Below is displaying the declarative secret definitions.
   - name: foo1
     key: go-vela/docs/foo1
@@ -30,11 +26,16 @@ secrets:
     key: go-vela/admins/foo3
     engine: native
     type: shared
+  - name: vault_token
+    key: go-vela/vault_token
+    engine: native
+    type: org
 
   # Below is displaying executing a secret plugin.
   - origin:
      name: External Vault Secret
      image: target/secret-vault:latest
+     secrets: [ vault_token ]
      parameters:
        addr: vault.company.com
        auth_method: token
@@ -42,7 +43,7 @@ secrets:
        token: sometoken
        items:
          - source: secret/vela
-           path: user    
+           path: user
 ```
 
 ## Tags
@@ -59,7 +60,7 @@ secrets:
 
 ```yaml
 ---
-secrets: 
+secrets:
     # Name of secret to reference in the pipeline.
   - name: postgres
 ```
@@ -78,18 +79,18 @@ The key is unique
 
 ```yaml
 ---
-secrets: 
-    # Path to secret to fetch from storage backend. Displaying a 
-    # repo type secret. 
+secrets:
+    # Path to secret to fetch from storage backend. Displaying a
+    # repo type secret.
   - key: go-vela/docs/foo1
 
-    # Path to secret to fetch from storage backend. Displaying a 
+    # Path to secret to fetch from storage backend. Displaying a
     # org type secret.
   - key: go-vela/foo1
-  
-    # Path to secret to fetch from storage backend. Displaying a 
+
+    # Path to secret to fetch from storage backend. Displaying a
     # shared type secret.
-  - key: go-vela/admins/foo1  
+  - key: go-vela/admins/foo1
 ```
 
 #### The `engine:` tag
@@ -100,9 +101,9 @@ To know what engines are available for your Vela installation, we recommend cons
 
 ```yaml
 ---
-secrets: 
+secrets:
     # Name of storage backend to fetch secret from, "native" signifies
-    # the backend provide it the Vela database. 
+    # the backend provide it the Vela database.
   - engine: native
 ```
 
@@ -110,9 +111,9 @@ secrets:
 
 ```yaml
 ---
-secrets: 
+secrets:
     # Type of secret to fetch from storage backend.
-    # By default, Vela can pull repo but tag accepts the 
+    # By default, Vela can pull repo but tag accepts the
     # following values: repo, org, and shared
   - type: repo
 ```

--- a/content/reference/yaml/secrets.md
+++ b/content/reference/yaml/secrets.md
@@ -113,7 +113,7 @@ secrets:
 ---
 secrets:
     # Type of secret to fetch from storage backend.
-    # By default, Vela can pull repo but tag accepts the
+    # By default, Vela can pull repo but type accepts the
     # following values: repo, org, and shared
   - type: repo
 ```

--- a/content/tour/secrets.md
+++ b/content/tour/secrets.md
@@ -59,14 +59,10 @@ steps:
         - v1.0.0
 
 secrets:
-  # This syntax is an implicit way of pulling a repo secret.
-  # You can see all secret pattens in the reference section.
-  - name: docker_password
-  - name: password
-
-  # Notice here I decided to use the explicit syntax. This allows
-  # me to alias the name here instead of using source/target syntax
-  # directly in the step
+  # Notice here how the name and the key don't need to match.
+  # This gives end users an ability to reuse or rename secrets with
+  # different names across their various pipelines. This is similar
+  # to the alias above, but allows for aliasing across the entire pipeline.
   - name: docker_username
     key: go-vela/docs/username
     engine: native

--- a/content/usage/examples/secrets_external.md
+++ b/content/usage/examples/secrets_external.md
@@ -119,7 +119,7 @@ secrets:
     engine: native
     type: org
 
-- origin:
+  - origin:
       name: private vault
       image: target/secret-vault:latest
       pull: always

--- a/content/usage/examples/secrets_external.md
+++ b/content/usage/examples/secrets_external.md
@@ -52,8 +52,13 @@ steps:
 
 
 secrets:
-  # Implicit secret definition.
+  # Note here how this pipeline uses an internal secret vault_token
+  # in the origin secret below to get additional secrets from an
+  # external service.
   - name: vault_token
+    key: go-vela/vault_token
+    engine: native
+    type: org
 
   - origin:
       name: private vault
@@ -66,7 +71,7 @@ secrets:
         username: octocat
         items:
           - source: secret/docker
-            path: docker  
+            path: docker
 ```
 
 ### Stages
@@ -109,10 +114,12 @@ stages:
           repo: index.docker.io/vela/hello-world
 
 secrets:
-  # Implicit secret definition.
   - name: vault_token
+    key: go-vela/vault_token
+    engine: native
+    type: org
 
-  - origin:
+- origin:
       name: private vault
       image: target/secret-vault:latest
       pull: always
@@ -123,5 +130,5 @@ secrets:
         username: octocat
         items:
           - source: secret/docker
-            path: docker  
+            path: docker
 ```

--- a/content/usage/examples/secrets_internal.md
+++ b/content/usage/examples/secrets_internal.md
@@ -53,11 +53,12 @@ steps:
 
 
 secrets:
-  # Implicit secret definition. This definition is only supported for native secrets of repository type.
   - name: docker_username
+    key: vela/hello-world/docker_username
+    engine: native
+    type: repo
 
-  # Declarative secret definition.
-  - name: foo1
+  - name: docker_password
     key: vela/hello-world/docker_password
     engine: native
     type: repo
@@ -100,12 +101,13 @@ stages:
           repo: index.docker.io/vela/hello-world
 
 secrets:
-  # Implicit secret definition. This definition is only supported for native secrets of repository type.
   - name: docker_username
+    key: vela/hello-world/docker_username
+    engine: native
+    type: repo
 
-  # Declarative secret definition.
-  - name: foo1
+  - name: docker_password
     key: vela/hello-world/docker_password
     engine: native
-    type: repo   
+    type: repo
 ```

--- a/content/usage/plugin.md
+++ b/content/usage/plugin.md
@@ -27,6 +27,9 @@ steps:
 
 secrets:
   - name: vault_token
+    key: go-vela/vault_token
+    engine: native
+    type: org
 
   - origin:
       name: plugin
@@ -38,7 +41,7 @@ secrets:
         auth_method: token
         items:
           - source: secret/docker
-            path: docker   
+            path: docker
 ```
 
 We pass these variables in Vela using the `parameters` block. Any variable passed to this block, will be injected into the step as `PARAMETER_<variable>`:
@@ -56,6 +59,9 @@ steps:
 
 secrets:
   - name: vault_token
+    key: go-vela/vault_token
+    engine: native
+    type: org
 
   - origin:
       name: vault
@@ -67,7 +73,7 @@ secrets:
 +       auth_method: token
 +       items:
 +         - source: secret/docker
-+           path: docker  
++           path: docker
 ```
 
 From the above example, the following environment variables would be added to the containers:


### PR DESCRIPTION
This change is removing the language around implicit secrets in preference for explicit secrets only. Implicit secrets can be nice and confusing and a whole can of worms, in addition to causing a small bit of troubleshooting woes for end users such as in https://github.com/go-vela/community/issues/158