### PR TITLE
fix(postgres): add password to postgres example

### DIFF
--- a/content/usage/examples/postgres.md
+++ b/content/usage/examples/postgres.md
@@ -39,6 +39,7 @@ services:
     pull: always
     environment:
       POSTGRES_USER: admin
+      POSTGRES_PASSWORD: password
       POSTGRES_DB: vela
 
 steps:
@@ -77,6 +78,7 @@ steps:
     pull: always
     environment:
       POSTGRES_USER: admin
+      POSTGRES_PASSWORD: password
       POSTGRES_DB: vela    
     detach: true
 


### PR DESCRIPTION
postgres won't start successfully without password env var