### PR TITLE
feat: add documentation for sync repos in API and CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ resources/
 node_modules/
 tech-doc-hugo
 package-lock.json
+.hugo_build.lock
 
 # IntelliJ project folder
 .idea/

--- a/content/reference/api/scm/_index.md
+++ b/content/reference/api/scm/_index.md
@@ -1,0 +1,14 @@
+---
+title: "SCM"
+linkTitle: "SCM"
+description: >
+  Learn how to use API endpoints for the SCM resource.
+---
+
+The below endpoints are available to operate on the `scm` resource.
+
+{{% alert color="warning" %}}
+This section assumes you already know how to authenticate to the API.
+
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
+{{% /alert %}}

--- a/content/reference/api/scm/sync.md
+++ b/content/reference/api/scm/sync.md
@@ -1,0 +1,51 @@
+---
+title: "Sync"
+linkTitle: "Sync"
+description: >
+  Learn how to change ownership of a repo.
+---
+
+## Endpoint
+
+```
+PATCH  /api/v1/scm/repos/:org/:repo/sync
+```
+
+## Parameters
+
+The following parameters are used to configure the endpoint:
+
+| Name   | Description          |
+| ------ | -------------------- |
+| `org`  | name of organization |
+| `repo` | name of repository   |
+
+## Responses
+
+| Status Code | Description                                         |
+| ----------- | --------------------------------------------------- |
+| `200`       | indicates the request has succeeded                 |
+| `401`       | indicates the user does not have proper permissions |
+
+## Sample
+
+{{% alert color="warning" %}}
+This section assumes you already know how to authenticate to the API.
+
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
+{{% /alert %}}
+
+#### Request
+
+```sh
+curl \
+  -X PATCH \
+  -H "Authorization: Bearer <token>" \
+  "http://127.0.0.1:8080/api/v1/scm/repos/github/octocat/sync"
+```
+
+#### Response
+
+```
+Repo github/octocat synced
+```

--- a/content/reference/api/scm/sync.md
+++ b/content/reference/api/scm/sync.md
@@ -2,7 +2,7 @@
 title: "Sync"
 linkTitle: "Sync"
 description: >
-  Learn how to change ownership of a repo.
+  Learn how to sync a repo with SCM.
 ---
 
 ## Endpoint
@@ -46,6 +46,6 @@ curl \
 
 #### Response
 
-```
-Repo github/octocat synced
+```sh
+repo "github/octocat" synced
 ```

--- a/content/reference/api/scm/syncAll.md
+++ b/content/reference/api/scm/syncAll.md
@@ -2,7 +2,7 @@
 title: "SyncAll"
 linkTitle: "SyncAll"
 description: >
-  Learn how to change ownership of a repo.
+  Learn how to sync org repos with SCM.
 ---
 
 ## Endpoint
@@ -45,6 +45,6 @@ curl \
 
 #### Response
 
-```
-Org github synced
+```sh
+org "github" synced
 ```

--- a/content/reference/api/scm/syncAll.md
+++ b/content/reference/api/scm/syncAll.md
@@ -1,0 +1,50 @@
+---
+title: "SyncAll"
+linkTitle: "SyncAll"
+description: >
+  Learn how to change ownership of a repo.
+---
+
+## Endpoint
+
+```
+PATCH  /api/v1/scm/orgs/:org/sync
+```
+
+## Parameters
+
+The following parameters are used to configure the endpoint:
+
+| Name   | Description          |
+| ------ | -------------------- |
+| `org`  | name of organization |
+
+## Responses
+
+| Status Code | Description                                         |
+| ----------- | --------------------------------------------------- |
+| `200`       | indicates the request has succeeded                 |
+| `401`       | indicates the user does not have proper permissions |
+
+## Sample
+
+{{% alert color="warning" %}}
+This section assumes you already know how to authenticate to the API.
+
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
+{{% /alert %}}
+
+#### Request
+
+```sh
+curl \
+  -X PATCH \
+  -H "Authorization: Bearer <token>" \
+  "http://127.0.0.1:8080/api/v1/scm/orgs/github/sync"
+```
+
+#### Response
+
+```
+Org github synced
+```

--- a/content/reference/cli/repo/sync.md
+++ b/content/reference/cli/repo/sync.md
@@ -30,7 +30,6 @@ This command also supports setting the following parameters via a configuration 
 
 - `org`
 - `repo`
-- `all`
 
 For more information, please review the [CLI config documentation](/docs/reference/cli/config/).
 {{% /alert %}}

--- a/content/reference/cli/repo/sync.md
+++ b/content/reference/cli/repo/sync.md
@@ -1,0 +1,69 @@
+---
+title: "Sync"
+linkTitle: "Sync"
+description: >
+  Learn how to sync repos in database with GitHub.
+---
+
+## Command
+
+```
+$ vela sync repo <parameters...> <arguments...>
+```
+
+{{% alert color="info" %}}
+For more information, you can run `vela sync repo --help`.
+{{% /alert %}}
+
+## Parameters
+
+The following parameters are used to configure the command:
+
+| Name     | Description                             | Environment Variables        |
+| -------- | --------------------------------------- | ---------------------------- |
+| `org`    | name of organization for the repository | `VELA_ORG`, `REPO_ORG`       |
+| `repo`   | name of repository                      | `VELA_REPO`, `REPO_NAME`     |
+| `all`    | bool flag to sync all repos in an org   | `VELA_SYNC_ALL`, `SYNC_ALL`  |
+
+{{% alert color="info" %}}
+This command also supports setting the following parameters via a configuration file:
+
+- `org`
+- `repo`
+- `all`
+
+For more information, please review the [CLI config documentation](/docs/reference/cli/config/).
+{{% /alert %}}
+
+## Samples
+
+{{% alert color="warning" %}}
+This section assumes you have already installed and setup the CLI.
+
+To install the CLI, please review the [installation documentation](/docs/reference/cli/install/).
+
+To setup the CLI, please review the [authentication documentation](/docs/reference/cli/authentication/).
+{{% /alert %}}
+
+#### Request
+
+```sh
+vela sync repo --org github --repo octocat
+```
+
+#### Response
+
+```sh
+repo "github/octocat" synced
+```
+
+#### Request
+
+```sh
+vela sync repo --org github --all
+```
+
+#### Response
+
+```sh
+org "github" synced


### PR DESCRIPTION
- added documentation for the SCM in the API section
- put `sync` and `syncAll` in the repo section of the CLI since that is how it is in the code
- added `.hugo_build.lock` to the `.gitignore` -- it's a new file that is generated with more recent versions of Hugo apparently