### PR TITLE
chore(secrets): docs for secrets metadata

### DIFF
--- a/content/reference/api/secret/add.md
+++ b/content/reference/api/secret/add.md
@@ -75,6 +75,11 @@ curl \
   "value": null,
   "type": "repo",
   "images": ["alpine"],
-  "events": ["push"]
+  "events": ["push"],
+  "allow_command": true,
+  "created_at": 1641314085,
+  "created_by": "octokitty",
+  "updated_at": 1641314085,
+  "updated_by": "octokitty"
 }
 ```

--- a/content/reference/api/secret/get.md
+++ b/content/reference/api/secret/get.md
@@ -63,7 +63,12 @@ curl \
     "value": null,
     "type": "repo",
     "images": ["alpine"],
-    "events": ["push"]
+    "events": ["push"],
+    "allow_command": true,
+    "created_at": 1641314085,
+    "created_by": "octokitty",
+    "updated_at": 1641314085,
+    "updated_by": "octokitty"
   },
   {
     "id": 2,
@@ -74,7 +79,12 @@ curl \
     "value": null,
     "type": "repo",
     "images": ["alpine"],
-    "events": ["push"]
+    "events": ["push"],
+    "allow_command": true,
+    "created_at": 1641314500,
+    "created_by": "octokitty",
+    "updated_at": 1641314500,
+    "updated_by": "octokitty"
   }
 ]
 ```

--- a/content/reference/api/secret/update.md
+++ b/content/reference/api/secret/update.md
@@ -73,6 +73,11 @@ curl \
   "value": "",
   "type": "repo",
   "images": ["alpine"],
-  "events": ["push", "tag"]
+  "events": ["push", "tag"],
+  "allow_command": true,
+  "created_at": 1641314085,
+  "created_by": "octokitty",
+  "updated_at": 1641314500,
+  "updated_by": "octocat"
 }
 ```

--- a/content/reference/api/secret/view.md
+++ b/content/reference/api/secret/view.md
@@ -63,6 +63,11 @@ curl \
   "value": "",
   "type": "repo",
   "images": ["alpine"],
-  "events": ["push"]
+  "events": ["push"],
+  "allow_command": true,
+  "created_at": 1641314085,
+  "created_by": "octokitty",
+  "updated_at": 1641314500,
+  "updated_by": "octocat"
 }
 ```

--- a/content/reference/cli/secret/view.md
+++ b/content/reference/cli/secret/view.md
@@ -75,4 +75,9 @@ images: null
 events:
   - push
   - pull_request
+allowcommand: true
+createdat: 1641312765
+createdby: octokitty
+updatedat: 1641312765
+updatedby: octokitty
 ```


### PR DESCRIPTION
Documentation that adds the newly created fields from [secrets metadata story](https://github.com/go-vela/server/pull/526). Also added in the `allow_command` field since that seemed to be missing.