### PR TITLE
feat: add docs for repo build limit

### DIFF
--- a/content/administration/server/reference/_index.md
+++ b/content/administration/server/reference/_index.md
@@ -270,6 +270,10 @@ This variable has a default value of `false`.
 
 This variable sets the default amount of concurrent builds a repo is allowed to run.
 
+In this context, concurrent builds refers to any `pending` or `running` builds for that repo.
+
+If the amount of concurrent builds for a repo matches the limit, then any new builds will be blocked from being created.
+
 The variable can be provided as an `integer`.
 
 {{% alert title="Note:" color="primary" %}}
@@ -313,6 +317,10 @@ This variable has a default value of `true`.
 ### VELA_MAX_BUILD_LIMIT
 
 This variable sets the maximum amount of concurrent builds a repo is allowed to run.
+
+In this context, concurrent builds refers to any `pending` or `running` builds for that repo.
+
+If the amount of concurrent builds for a repo matches the limit, then any new builds will be blocked from being created.
 
 The variable can be provided as an `integer`.
 

--- a/content/administration/server/reference/_index.md
+++ b/content/administration/server/reference/_index.md
@@ -266,14 +266,24 @@ The variable can be provided as a `boolean`.
 This variable has a default value of `false`.
 {{% /alert %}}
 
-### VELA_DEFAULT_BUILD_TIMEOUT
+### VELA_DEFAULT_BUILD_LIMIT
 
-This variable sets the default maximum duration of time a build is allowed to run on a worker.
+This variable sets the default amount of concurrent builds a repo is allowed to run.
 
 The variable can be provided as an `integer`.
 
 {{% alert title="Note:" color="primary" %}}
-This variable has a default value of `0`.
+This variable has a default value of `10`.
+{{% /alert %}}
+
+### VELA_DEFAULT_BUILD_TIMEOUT
+
+This variable sets the default duration of time a build is allowed to run on a worker.
+
+The variable can be provided as an `integer`.
+
+{{% alert title="Note:" color="primary" %}}
+This variable has a default value of `30`.
 {{% /alert %}}
 
 ### VELA_DISABLE_WEBHOOK_VALIDATION
@@ -298,6 +308,18 @@ The variable can be provided as a `boolean`.
 This variable should only be used for local development.
 
 This variable has a default value of `true`.
+{{% /alert %}}
+
+### VELA_MAX_BUILD_LIMIT
+
+This variable sets the maximum amount of concurrent builds a repo is allowed to run.
+
+The variable can be provided as an `integer`.
+
+{{% alert title="Note:" color="primary" %}}
+This variable has a default value of `30`.
+
+This variable should match [the `VELA_MAX_BUILD_LIMIT` variable](/docs/administration/ui/reference/#vela_max_build_limit) provided to the UI.
 {{% /alert %}}
 
 ### VELA_MODIFICATION_ADDR

--- a/content/administration/ui/reference/_index.md
+++ b/content/administration/ui/reference/_index.md
@@ -55,3 +55,25 @@ The variable can be provided as a `string`.
 {{% alert title="Note:" color="primary" %}}
 This variable has a default value of `https://github.com/go-vela/ui/issues/new/`.
 {{% /alert %}}
+
+### VELA_LOG_BYTES_LIMIT
+
+This variable sets the maximum amount of bytes for logs the UI will attempt to render.
+
+The variable can be provided as an `integer`.
+
+{{% alert title="Note:" color="primary" %}}
+This variable has a default value of `20000` (2 MB).
+{{% /alert %}}
+
+### VELA_MAX_BUILD_LIMIT
+
+This variable sets the maximum amount of concurrent builds a repo is allowed to run.
+
+The variable can be provided as an `integer`.
+
+{{% alert title="Note:" color="primary" %}}
+This variable has a default value of `30`.
+
+This variable should match [the `VELA_MAX_BUILD_LIMIT` variable](/docs/administration/server/reference/#vela_max_build_limit) provided to the server.
+{{% /alert %}}

--- a/content/administration/ui/reference/_index.md
+++ b/content/administration/ui/reference/_index.md
@@ -70,6 +70,10 @@ This variable has a default value of `20000` (2 MB).
 
 This variable sets the maximum amount of concurrent builds a repo is allowed to run.
 
+In this context, concurrent builds refers to any `pending` or `running` builds for that repo.
+
+If the amount of concurrent builds for a repo matches the limit, then any new builds will be blocked from being created.
+
 The variable can be provided as an `integer`.
 
 {{% alert title="Note:" color="primary" %}}

--- a/content/reference/api/repo/add.md
+++ b/content/reference/api/repo/add.md
@@ -64,6 +64,7 @@ curl \
   "link": "https://github.com/github/octocat",
   "clone": "https://github.com/github/octocat.git",
   "branch": "master",
+  "build_limit": 10,
   "timeout": 60,
   "counter": 0,
   "visibility": "public",
@@ -74,6 +75,7 @@ curl \
   "allow_push": true,
   "allow_deploy": false,
   "allow_tag": false,
-  "allow_comment": false
+  "allow_comment": false,
+  "pipeline_type": "yaml"
 }
 ```

--- a/content/reference/api/repo/get.md
+++ b/content/reference/api/repo/get.md
@@ -52,6 +52,7 @@ curl \
     "link": "https://github.com/github/octocat",
     "clone": "https://github.com/github/octocat.git",
     "branch": "master",
+    "build_limit": 10,
     "timeout": 60,
     "counter": 0,
     "visibility": "public",
@@ -62,7 +63,8 @@ curl \
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
-    "allow_comment": false
+    "allow_comment": false,
+    "pipeline_type": "yaml"
   },
   {
     "id": 2,
@@ -73,6 +75,7 @@ curl \
     "link": "https://github.com/github/octokitty",
     "clone": "https://github.com/github/octokitty.git",
     "branch": "master",
+    "build_limit": 10,
     "timeout": 60,
     "counter": 0,
     "visibility": "public",
@@ -83,7 +86,8 @@ curl \
     "allow_push": true,
     "allow_deploy": false,
     "allow_tag": false,
-    "allow_comment": false
+    "allow_comment": false,
+    "pipeline_type": "yaml"
   }
 ]
 ```

--- a/content/reference/api/repo/update.md
+++ b/content/reference/api/repo/update.md
@@ -70,6 +70,7 @@ curl \
   "link": "https://github.com/github/octocat",
   "clone": "https://github.com/github/octocat.git",
   "branch": "master",
+  "build_limit": 10,
   "timeout": 60,
   "counter": 0,
   "visibility": "public",
@@ -80,6 +81,7 @@ curl \
   "allow_push": true,
   "allow_deploy": false,
   "allow_tag": true,
-  "allow_comment": false
+  "allow_comment": false,
+  "pipeline_type": "yaml"
 }
 ```

--- a/content/reference/api/repo/view.md
+++ b/content/reference/api/repo/view.md
@@ -60,6 +60,7 @@ curl \
   "link": "https://github.com/github/octocat",
   "clone": "https://github.com/github/octocat.git",
   "branch": "master",
+  "build_limit": 10,
   "timeout": 60,
   "counter": 0,
   "visibility": "public",
@@ -70,6 +71,7 @@ curl \
   "allow_push": true,
   "allow_deploy": false,
   "allow_tag": false,
-  "allow_comment": false
+  "allow_comment": false,
+  "pipeline_type": "yaml"
 }
 ```

--- a/content/reference/cli/repo/add.md
+++ b/content/reference/cli/repo/add.md
@@ -19,21 +19,23 @@ For more information, you can run `vela add repo --help`.
 
 The following parameters are used to configure the command:
 
-| Name         | Description                                        | Environment Variables                |
-| ------------ | -------------------------------------------------- | ------------------------------------ |
-| `org`        | name of organization for the repository            | `VELA_ORG`, `REPO_ORG`               |
-| `repo`       | name of repository                                 | `VELA_REPO`, `REPO_NAME`             |
-| `link`       | full URL for the repository                        | `VELA_LINK`, `REPO_LINK`             |
-| `branch`     | default branch for the repository                  | `VELA_BRANCH`, `REPO_BRANCH`         |
-| `clone`      | clone URL for the repository                       | `VELA_CLONE`, `REPO_CLONE`           |
-| `visibility` | access level required to view the repository       | `VELA_VISIBILITY`, `REPO_VISIBILITY` |
-| `timeout`    | max time allowed per build                         | `VELA_TIMEOUT`, `REPO_TIMEOUT`       |
-| `counter`    | set a value for a new build number                 | `VELA_COUNTER`, `REPO_COUNTER`       |
-| `private`    | disables public access to the repository           | `VELA_PRIVATE`, `REPO_PRIVATE`       |
-| `trusted`    | elevates permissions for builds for the repository | `VELA_TRUSTED`, `REPO_TRUSTED`       |
-| `active`     | enables/disables the repository                    | `VELA_ACTIVE`, `REPO_ACTIVE`         |
-| `event`      | events to trigger builds for the repository        | `VELA_EVENTS`, `REPO_EVENTS`         |
-| `output`     | format the output for the repository               | `VELA_OUTPUT`, `REPO_OUTPUT`         |
+| Name            | Description                                        | Environment Variables                  |
+| --------------- | -------------------------------------------------- | -------------------------------------- |
+| `org`           | name of organization for the repository            | `VELA_ORG`, `REPO_ORG`                 |
+| `repo`          | name of repository                                 | `VELA_REPO`, `REPO_NAME`               |
+| `branch`        | default branch for the repository                  | `VELA_BRANCH`, `REPO_BRANCH`           |
+| `link`          | full URL for the repository                        | `VELA_LINK`, `REPO_LINK`               |
+| `clone`         | clone URL for the repository                       | `VELA_CLONE`, `REPO_CLONE`             |
+| `visibility`    | access level required to view the repository       | `VELA_VISIBILITY`, `REPO_VISIBILITY`   |
+| `build.limit`   | limit of concurrent builds allowed for repository  | `VELA_BUILD_LIMIT`, `REPO_BUILD_LIMIT` |
+| `timeout`       | max time allowed per build                         | `VELA_TIMEOUT`, `REPO_TIMEOUT`         |
+| `counter`       | set a value for a new build number                 | `VELA_COUNTER`, `REPO_COUNTER`         |
+| `private`       | disables public access to the repository           | `VELA_PRIVATE`, `REPO_PRIVATE`         |
+| `trusted`       | elevates permissions for builds for the repository | `VELA_TRUSTED`, `REPO_TRUSTED`         |
+| `active`        | enables/disables the repository                    | `VELA_ACTIVE`, `REPO_ACTIVE`           |
+| `event`         | events to trigger builds for the repository        | `VELA_EVENTS`, `REPO_EVENTS`           |
+| `pipeline-type` | type of base pipeline for the compiler to render   | `VELA_PIPELINE_TYPE`, `PIPELINE_TYPE`  |
+| `output`        | format the output for the repository               | `VELA_OUTPUT`, `REPO_OUTPUT`           |
 
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
@@ -76,6 +78,7 @@ fullname: github/octocat
 link: https://github.com/github/octocat
 clone: https://github.com/github/octocat.git
 branch: master
+buildlimit: 10
 timeout: 60
 timeout: 0
 visibility: public
@@ -87,4 +90,5 @@ allowpush: true
 allowdeploy: false
 allowtag: false
 allowcomment: false
+pipelinetype: yaml
 ```

--- a/content/reference/cli/repo/update.md
+++ b/content/reference/cli/repo/update.md
@@ -19,21 +19,23 @@ For more information, you can run `vela update repo --help`.
 
 The following parameters are used to configure the command:
 
-| Name         | Description                                        | Environment Variables                |
-| ------------ | -------------------------------------------------- | ------------------------------------ |
-| `org`        | name of organization for the repository            | `VELA_ORG`, `REPO_ORG`               |
-| `repo`       | name of repository                                 | `VELA_REPO`, `REPO_NAME`             |
-| `link`       | full URL for the repository                        | `VELA_LINK`, `REPO_LINK`             |
-| `branch`     | default branch for the repository                  | `VELA_BRANCH`, `REPO_BRANCH`         |
-| `clone`      | clone URL for the repository                       | `VELA_CLONE`, `REPO_CLONE`           |
-| `visibility` | access level required to view the repository       | `VELA_VISIBILITY`, `REPO_VISIBILITY` |
-| `timeout`    | max time allowed per build                         | `VELA_TIMEOUT`, `REPO_TIMEOUT`       |
-| `counter`    | set a value for a new build number                 | `VELA_COUNTER`, `REPO_COUNTER`       |
-| `private`    | disables public access to the repository           | `VELA_PRIVATE`, `REPO_PRIVATE`       |
-| `trusted`    | elevates permissions for builds for the repository | `VELA_TRUSTED`, `REPO_TRUSTED`       |
-| `active`     | enables/disables the repository                    | `VELA_ACTIVE`, `REPO_ACTIVE`         |
-| `event`      | events to trigger builds for the repository        | `VELA_EVENTS`, `REPO_EVENTS`         |
-| `output`     | format the output for the repository               | `VELA_OUTPUT`, `REPO_OUTPUT`         |
+| Name            | Description                                        | Environment Variables                  |
+| --------------- | -------------------------------------------------- | -------------------------------------- |
+| `org`           | name of organization for the repository            | `VELA_ORG`, `REPO_ORG`                 |
+| `repo`          | name of repository                                 | `VELA_REPO`, `REPO_NAME`               |
+| `branch`        | default branch for the repository                  | `VELA_BRANCH`, `REPO_BRANCH`           |
+| `link`          | full URL for the repository                        | `VELA_LINK`, `REPO_LINK`               |
+| `clone`         | clone URL for the repository                       | `VELA_CLONE`, `REPO_CLONE`             |
+| `visibility`    | access level required to view the repository       | `VELA_VISIBILITY`, `REPO_VISIBILITY`   |
+| `build.limit`   | limit of concurrent builds allowed for repository  | `VELA_BUILD_LIMIT`, `REPO_BUILD_LIMIT` |
+| `timeout`       | max time allowed per build                         | `VELA_TIMEOUT`, `REPO_TIMEOUT`         |
+| `counter`       | set a value for a new build number                 | `VELA_COUNTER`, `REPO_COUNTER`         |
+| `private`       | disables public access to the repository           | `VELA_PRIVATE`, `REPO_PRIVATE`         |
+| `trusted`       | elevates permissions for builds for the repository | `VELA_TRUSTED`, `REPO_TRUSTED`         |
+| `active`        | enables/disables the repository                    | `VELA_ACTIVE`, `REPO_ACTIVE`           |
+| `event`         | events to trigger builds for the repository        | `VELA_EVENTS`, `REPO_EVENTS`           |
+| `pipeline-type` | type of base pipeline for the compiler to render   | `VELA_PIPELINE_TYPE`, `PIPELINE_TYPE`  |
+| `output`        | format the output for the repository               | `VELA_OUTPUT`, `REPO_OUTPUT`           |
 
 {{% alert color="info" %}}
 This command also supports setting the following parameters via a configuration file:
@@ -76,6 +78,7 @@ fullname: github/octocat
 link: https://github.com/github/octocat
 clone: https://github.com/github/octocat.git
 branch: master
+buildlimit: 10
 timeout: 60
 counter: 0
 visibility: public
@@ -87,4 +90,5 @@ allowpush: true
 allowdeploy: false
 allowtag: true
 allowcomment: false
+pipelinetype: yaml
 ```

--- a/content/reference/cli/repo/view.md
+++ b/content/reference/cli/repo/view.md
@@ -66,6 +66,7 @@ fullname: github/octocat
 link: https://github.com/github/octocat
 clone: https://github.com/github/octocat.git
 branch: master
+buildlimit: 10
 timeout: 60
 counter: 0
 visibility: public
@@ -77,4 +78,5 @@ allowpush: true
 allowdeploy: false
 allowtag: false
 allowcomment: false
+pipelinetype: yaml
 ```

--- a/content/reference/environment/variables.md
+++ b/content/reference/environment/variables.md
@@ -104,24 +104,25 @@ The following table includes variables only available during the **tag** event.
 
 #### Repository Environment Variables
 
-| Key                       | Value                                        | Explanation                                |
-| ------------------------- | -------------------------------------------- | ------------------------------------------ |
-| `VELA_REPO_ACTIVE`        | `true`                                       | active setting for the repository          |
-| `VELA_REPO_ALLOW_COMMENT` | `false`                                      | comment enabled setting for the repository |
-| `VELA_REPO_ALLOW_DEPLOY`  | `false`                                      | deploy enabled setting for the repository  |
-| `VELA_REPO_ALLOW_PULL`    | `true`                                       | pull enabled setting for the repository    |
-| `VELA_REPO_ALLOW_PUSH`    | `true`                                       | push enabled setting for the repository    |
-| `VELA_REPO_ALLOW_TAG`     | `false`                                      | tag enabled setting for the repository     |
-| `VELA_REPO_BRANCH`        | `main`                                       | default branch of the repository           |
-| `VELA_REPO_CLONE`         | `https://github.com/octocat/hello-world.git` | clone url of the repository                |
-| `VELA_REPO_FULL_NAME`     | `octocat/hello-world`                        | full name of the repository                |
-| `VELA_REPO_LINK`          | `https://github.com/octocat/hello-world`     | direct url of the repository               |
-| `VELA_REPO_NAME`          | `hello-world`                                | name of the repository                     |
-| `VELA_REPO_ORG`           | `octocat`                                    | org of the repository                      |
-| `VELA_REPO_PRIVATE`       | `false`                                      | privacy setting for the repository         |
-| `VELA_REPO_TIMEOUT`       | `30`                                         | timeout setting for the repository         |
-| `VELA_REPO_TRUSTED`       | `false`                                      | trusted setting for the repository         |
-| `VELA_REPO_VISIBILITY`    | `public`                                     | visibility setting for the repository      |
+| Key                       | Value                                        | Explanation                                   |
+| ------------------------- | -------------------------------------------- | --------------------------------------------- |
+| `VELA_REPO_ACTIVE`        | `true`                                       | active setting for the repository             |
+| `VELA_REPO_ALLOW_COMMENT` | `false`                                      | comment enabled setting for the repository    |
+| `VELA_REPO_ALLOW_DEPLOY`  | `false`                                      | deploy enabled setting for the repository     |
+| `VELA_REPO_ALLOW_PULL`    | `true`                                       | pull enabled setting for the repository       |
+| `VELA_REPO_ALLOW_PUSH`    | `true`                                       | push enabled setting for the repository       |
+| `VELA_REPO_ALLOW_TAG`     | `false`                                      | tag enabled setting for the repository        |
+| `VELA_REPO_BRANCH`        | `main`                                       | default branch of the repository              |
+| `VELA_REPO_BUILD_LIMIT`   | `10`                                         | limit of concurrent builds for the repository |
+| `VELA_REPO_CLONE`         | `https://github.com/octocat/hello-world.git` | clone url of the repository                   |
+| `VELA_REPO_FULL_NAME`     | `octocat/hello-world`                        | full name of the repository                   |
+| `VELA_REPO_LINK`          | `https://github.com/octocat/hello-world`     | direct url of the repository                  |
+| `VELA_REPO_NAME`          | `hello-world`                                | name of the repository                        |
+| `VELA_REPO_ORG`           | `octocat`                                    | org of the repository                         |
+| `VELA_REPO_PRIVATE`       | `false`                                      | privacy setting for the repository            |
+| `VELA_REPO_TIMEOUT`       | `30`                                         | timeout setting for the repository            |
+| `VELA_REPO_TRUSTED`       | `false`                                      | trusted setting for the repository            |
+| `VELA_REPO_VISIBILITY`    | `public`                                     | visibility setting for the repository         |
 
 #### User Environment Variables
 


### PR DESCRIPTION
Dependent on https://github.com/go-vela/ui/pull/494, https://github.com/go-vela/server/pull/558, https://github.com/go-vela/cli/pull/317 and https://github.com/go-vela/types/pull/219

Closes https://github.com/go-vela/community/issues/27
Closes https://github.com/go-vela/community/issues/162

Based off of https://github.com/go-vela/community/blob/master/proposals/2020/12-16_rate-limiting.md

This adds documentation for the build rate limiting functionality added to Vela.