### PR TITLE
docs(executor): document max log size

### DIFF
--- a/content/administration/worker/reference/_index.md
+++ b/content/administration/worker/reference/_index.md
@@ -149,6 +149,18 @@ The possible options to provide for this variable are:
 * `time-chunks`
 {{% /alert %}}
 
+### VELA_EXECUTOR_MAX_LOG_SIZE
+
+This configuration variable is used by the [executor component](/docs/administration/worker/reference/executor/) for the worker.
+
+This variable sets the maximum number of bytes for logs allowed to be uploaded per step.
+
+The variable can be provided as an `integer`.
+
+{{% alert title="Note:" color="primary" %}}
+This variable has a default value of `0`. No limit.
+{{% /alert %}}
+
 ### VELA_QUEUE_CLUSTER
 
 This configuration variable is used by the [queue component](/docs/administration/worker/reference/queue/) for the worker.

--- a/content/administration/worker/reference/executor.md
+++ b/content/administration/worker/reference/executor.md
@@ -13,10 +13,11 @@ Throughout the lifecycle of these resources, this component will track and repor
 
 The following options are used to configure the component:
 
-| Name                  | Description                                       | Required | Default       | Environment Variables                               |
-| --------------------- | ------------------------------------------------- | -------- | ------------- | --------------------------------------------------- |
-| `executor.driver`     | type of client to control and operate executor    | `true`   | `linux`       | `EXECUTOR_DRIVER`<br>`VELA_EXECUTOR_DRIVER`         |
-| `executor.log_method` | method used to publish logs back to the server    | `true`   | `byte-chunks` | `EXECUTOR_LOG_METHOD`<br>`VELA_EXECUTOR_LOG_METHOD` |
+| Name                    | Description                                       | Required | Default        | Environment Variables                                   |
+| ----------------------- | ------------------------------------------------- | -------- | -------------- | ------------------------------------------------------- |
+| `executor.driver`       | type of client to control and operate executor    | `true`   | `linux`        | `EXECUTOR_DRIVER`<br>`VELA_EXECUTOR_DRIVER`             |
+| `executor.log_method`   | method used to publish logs back to the server    | `true`   | `byte-chunks`  | `EXECUTOR_LOG_METHOD`<br>`VELA_EXECUTOR_LOG_METHOD`     |
+| `executor.max_log_size` | maximum log size (in bytes)                       | `false`  | `0` (no limit) | `EXECUTOR_MAX_LOG_SIZE`<br>`VELA_EXECUTOR_MAX_LOG_SIZE` |
 
 {{% alert title="Note:" color="primary" %}}
 For more information on these configuration options, please see the [worker reference](/docs/administration/worker/reference/).


### PR DESCRIPTION
document max log size introduced here: https://github.com/go-vela/worker/pull/244