### PR TITLE
enhance(stage): add more clarity about needs tag

### DIFF
--- a/content/tour/stages.md
+++ b/content/tour/stages.md
@@ -64,6 +64,8 @@ $ vela exec pipeline
 [stage: greeting][step: Greeting] Hello, World
 [stage: welcome][step: Welcome] $ echo "Welcome to the Vela docs"
 [stage: welcome][step: Welcome] Welcome to the Vela docs
+[stage: goodbye][step: Goodbye] $ echo "Goodbye, World"
+[stage: goodbye][step: Goodbyte] Goodbye, World
 ```
 
 <!-- section break -->

--- a/content/tour/stages.md
+++ b/content/tour/stages.md
@@ -8,7 +8,7 @@ description: >
 
 A stages pipelines are designed to parallelize one-to-many sets of step tasks.
 
-By design all of the stages will run at the same time unless the user uses a `needs:` YAML tag to control the flow of stage executions.
+By design all of the stages will run at the same time unless the user uses a `needs:` YAML tag to control the flow of stage executions (see example). Note: even if every step within a stage is skipped, the stage still runs. Do not use `needs` as a stage-level equivalent to `rulesets`. 
 
 These pipelines do not have a minimum defined length and will always execute steps within a stage in the order defined. Stages always run on the same host so it's important to take into consideration the size of the worker running your builds.
 
@@ -45,6 +45,15 @@ stages:
         image: alpine
         commands:
           - echo "Welcome to the Vela docs"
+  
+  goodbye:
+    # will wait for greeting and welcome to finish
+    needs: [greeting, welcome]
+    steps:
+      - name: Goodbye
+        image: alpine
+        commands:
+          - echo "Goodbye, World"
 ```
 
 


### PR DESCRIPTION
Adding another sentence of explanation as well as an example stage. This is a response to a user who expected the `needs` tag to prevent a stage from running if the needed stage skipped all its steps. Hopefully this addition to the docs helps establish that `needs` is purely a parallelization tool.