### PR TITLE
chore(cli): adding documentation for other flags in validate pipeline command

### DIFF
--- a/content/reference/cli/pipeline/validate.md
+++ b/content/reference/cli/pipeline/validate.md
@@ -19,10 +19,16 @@ For more information, please run `vela validate pipeline --help`.
 
 The following parameters are used to configure the command:
 
-| Name   | Description                       | Environment Variables        |
-| ------ | --------------------------------- | ---------------------------- |
-| `file` | name of the file for the pipeline | `VELA_FILE`, `PIPELINE_FILE` |
-| `path` | path to the file for the pipeline | `VELA_PATH`, `PIPELINE_PATH` |
+| Name                    | Description                                                  | Environment Variables                                 |
+| ----------------------- | ------------------------------------------------------------ | ----------------------------------------------------- |
+| `file`                  | name of the file for the pipeline                            | `VELA_FILE`, `PIPELINE_FILE`                          |
+| `path`                  | path to the file for the pipeline                            | `VELA_PATH`, `PIPELINE_PATH`                          |
+| `ref`                   | repository reference for the pipeline                        | `VELA_REF`, `PIPELINE_REF`                            |
+| `template`              | enables templates to be included in pipeline validation      | `VELA_TEMPLATE`, `PIPELINE_TEMPLATE`                  |
+| `template-file`         | enables using a local template file for expansion            | `VELA_TEMPLATE_FILE`, `PIPELINE_TEMPLATE_FILE`        |
+| `remote`                | enables validating a pipeline on a remote server             | `VELA_REMOTE`, `PIPELINE_REMOTE`                      |
+| `compiler.github.token` | github compiler token                                        | `VELA_COMPILER_GITHUB_TOKEN`, `COMPILER_GITHUB_TOKEN` |
+| `compiler.github.url`   | github url, used by compiler, for pulling registry templates | `VELA_COMPILER_GITHUB_URL`, `COMPILER_GITHUB_URL`     |
 
 ## Permissions
 
@@ -37,10 +43,20 @@ To install the CLI, please review the [installation documentation](/docs/referen
 To setup the CLI, please review the [authentication documentation](/docs/reference/cli/authentication/).
 {{% /alert %}}
 
-#### Request
+#### Simple Request
 
 ```sh
 vela validate pipeline
+```
+
+#### Expanded Template Request (GitHub)
+```sh
+vela validate pipeline --template --compiler.github.token <token> --compiler.github.url https://git.example.com
+```
+
+#### Expanded Template Request (Local)
+```sh
+vela validate pipeline --template --template-file name:/path/to/file
 ```
 
 #### Response


### PR DESCRIPTION
The `vela validate pipeline --help` has all this info, but I figured templates are used so much that having it documented on the docs site would be beneficial. 