### PR TITLE
docs: replace vela-server.localhost with vela.example.com

### DIFF
--- a/content/reference/cli/authentication.md
+++ b/content/reference/cli/authentication.md
@@ -32,13 +32,13 @@ Log in:
 vela login --api.addr <vela server url>
 
 # Example
-vela login --api.addr https://vela-server.localhost
+vela login --api.addr https://vela.example.com
 ```
 
 Confirm authentication via browser prompt:
 
 ```
-Open https://vela-server.localhost in your browser and complete authentication (Press Enter to confirm):
+Open https://vela.example.com in your browser and complete authentication (Press Enter to confirm):
 ```
 
 Confirm to generate or update the configuration file prompt:
@@ -56,7 +56,7 @@ For more information, you can visit the [CLI config documentation](/docs/referen
 Configure the environment with the `VELA_ADDR` environment variable:
 
 ```sh
-export VELA_ADDR=https://vela-server.localhost
+export VELA_ADDR=https://vela.example.com
 ```
 
 Log in and confirm the two prompts as stated above:
@@ -78,5 +78,5 @@ Log in and confirm the two prompts as stated above:
 vela login --api.addr <vela server url>
 
 # Example
-vela login --api.addr https://vela-server.localhost
+vela login --api.addr https://vela.example.com
 ```

--- a/content/reference/cli/config/generate.md
+++ b/content/reference/cli/config/generate.md
@@ -51,14 +51,14 @@ To setup the CLI, please review the [authentication documentation](/docs/referen
 #### Request
 
 ```sh
-vela generate config --api.addr https://vela-server.localhost --log.level info
+vela generate config --api.addr https://vela.example.com --log.level info
 ```
 
 #### Response
 
 ```sh
 api:
-  addr: https://vela-server.localhost
+  addr: https://vela.example.com
 log:
   level: info
 no-git: "false"

--- a/content/reference/cli/config/update.md
+++ b/content/reference/cli/config/update.md
@@ -57,7 +57,7 @@ vela update config --org github
 
 ```sh
 api:
-  addr: https://vela-server.localhost
+  addr: https://vela.example.com
   access_token: superSecretAccessToken
   refresh_token: superSecretRefreshToken
   version: v1

--- a/content/reference/cli/config/view.md
+++ b/content/reference/cli/config/view.md
@@ -39,7 +39,7 @@ vela view config
 
 ```sh
 api:
-  addr: https://vela-server.localhost
+  addr: https://vela.example.com
   access_token: superSecretAccessToken
   refresh_token: superSecretRefreshToken
   version: v1

--- a/content/reference/environment/variables.md
+++ b/content/reference/environment/variables.md
@@ -25,7 +25,7 @@ The following environment variables are injected into every step, service, or se
 | `VELA_BUILD_ENQUEUED`     | `1556720958`                                                | unix timestamp representing build enqueued time                     |
 | `VELA_BUILD_EVENT`        | `push`                                                      | webhook event that triggered the build                              |
 | `VELA_BUILD_HOST`         | `vela-worker-1`                                             | fully qualified domain name of the worker the build was executed on |
-| `VELA_BUILD_LINK`         | `https://vela-server.localhost/octocat/hello-world/1`       | link to the build in the UI                                         |
+| `VELA_BUILD_LINK`         | `https://vela.example.com/octocat/hello-world/1`       | link to the build in the UI                                         |
 | `VELA_BUILD_MESSAGE`      | `Merge pull request #6 from octocat/patch-1`                | message from the source commit                                      |
 | `VELA_BUILD_NUMBER`       | `1`                                                         | build number                                                        |
 | `VELA_BUILD_PARENT`       | `1`                                                         | previous build number                                               |
@@ -91,7 +91,7 @@ The following table includes variables only available during the **tag** event.
 | Key              | Value                                             | Explanation                                                         |
 | ---------------- |---------------------------------------------------|---------------------------------------------------------------------|
 | `VELA`           | `true`                                            | environment is Vela                                                 |
-| `VELA_ADDR`      | `vela-server.localhost`                           | fully qualified domain name of the Vela server                      |
+| `VELA_ADDR`      | `vela.example.com`                           | fully qualified domain name of the Vela server                      |
 | `VELA_CHANNEL`   | `vela`                                            | queue channel the build was published to                            |
 | `VELA_DATABASE`  | `postgres`                                        | database Vela is connected to                                       |
 | `VELA_HOST`      | `vela-worker-1`                                   | fully qualified domain name of the worker the build was executed on |

--- a/content/usage/badge.md
+++ b/content/usage/badge.md
@@ -18,7 +18,7 @@ The server has an endpoint that will return an SVG badge for the default branch 
 https://<vela server>/badge/<org>/<repo>/status.svg
 
 # Example
-https://vela-server.localhost/badge/octocat/Hello-World/status.svg
+https://vela.example.com/badge/octocat/Hello-World/status.svg
 ```
 
 In addition you can specify which branch you want to get a badge for by supplying a `?branch=` query parameter in the URL.
@@ -28,7 +28,7 @@ In addition you can specify which branch you want to get a badge for by supplyin
 https://<vela server>/badge/<org>/<repo>/status.svg?branch=<branch name>
 
 # Example
-https://vela-server.localhost/badge/octocat/Hello-World/status.svg?branch=not_master
+https://vela.example.com/badge/octocat/Hello-World/status.svg?branch=not_master
 ```
 
 ### Embedding in Markdown
@@ -40,5 +40,5 @@ To embed your badge in your markdown formatted file, follow this example:
 [![Build Status](https://<vela server>/badge/<org>/<repo>/status.svg)](https://<vela server>/badge/<org>/<repo>)
 
 # Example
-[![Build Status](https://vela-server.localhost/badge/octocat/Hello-World/status.svg)](https://vela-server.localhost/badge/octocat/Hello-World)
+[![Build Status](https://vela.example.com/badge/octocat/Hello-World/status.svg)](https://vela.example.com/badge/octocat/Hello-World)
 ```


### PR DESCRIPTION
Replace references of `vela-server.localhost` with `vela.example.com` to have consistency amongst examples.