### PR TITLE
Fixes dead "edit" hyperlinks

### DIFF
--- a/themes/docsy/layouts/partials/page-meta-links.html
+++ b/themes/docsy/layouts/partials/page-meta-links.html
@@ -4,15 +4,15 @@
 {{ $gh_project_repo := ($.Param "github_project_repo") }}
 {{ if $gh_repo }}
 <div class="td-page-meta ml-2 pb-1 pt-2 mb-0">
-{{ $editURL := printf "%s/edit/master/content/%s" $gh_repo .Path }}
+{{ $editURL := printf "%s/edit/main/content/%s" $gh_repo .Path }}
 {{ if and ($gh_subdir) (.Site.Language.Lang) }}
-{{ $editURL = printf "%s/edit/master/%s/content/%s/%s" $gh_repo $gh_subdir ($.Site.Language.Lang) $.Path }}
+{{ $editURL = printf "%s/edit/main/%s/content/%s/%s" $gh_repo $gh_subdir ($.Site.Language.Lang) $.Path }}
 {{/*
 {{ else if .Site.Language.Lang }}
-{{ $editURL = printf "%s/edit/master/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
+{{ $editURL = printf "%s/edit/main/content/%s/%s" $gh_repo ($.Site.Language.Lang) .Path }}
 */}}
 {{ else if $gh_subdir }}
-{{ $editURL = printf "%s/edit/master/%s/content/%s" $gh_repo $gh_subdir $.Path }}
+{{ $editURL = printf "%s/edit/main/%s/content/%s" $gh_repo $gh_subdir $.Path }}
 {{ end }}
 {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (htmlEscape $.Title )}}
 <a href="{{ $editURL }}" target="_blank"><i class="fa fa-edit fa-fw"></i> {{ T "post_edit_this" }}</a>


### PR DESCRIPTION
The `master` branch was renamed/replaced with `main`, but these "edit" hyperlinks weren't updated so they currently return 404.