### PR TITLE
feat(worker/env): add docs for enforce trusted repos & remove volume / privileged ref

### DIFF
--- a/content/installation/worker/reference/_index.md
+++ b/content/installation/worker/reference/_index.md
@@ -163,6 +163,18 @@ The variable can be provided as an `integer`.
 This variable has a default value of `0`. No limit.
 {{% /alert %}}
 
+### VELA_EXECUTOR_ENFORCE_TRUSTED_REPOS
+
+This configuration variable is used by the [executor component](/docs/installation/worker/reference/executor/) for the worker.
+
+This variable sets whether or not the executor will verify a repository is `trusted` before executing a build that contains privileged images (see [runtime privileged images](/docs/installation/worker/reference/#vela_runtime_privileged_images)). 
+
+The variable can be provided as a `boolean`.
+
+{{% alert title="Note:" color="primary" %}}
+This variable has a default value of `true`. 
+{{% /alert %}}
+
 ### VELA_QUEUE_CLUSTER
 
 This configuration variable is used by the [queue component](/docs/installation/worker/reference/queue/) for the worker.

--- a/content/installation/worker/reference/runtime.md
+++ b/content/installation/worker/reference/runtime.md
@@ -20,7 +20,7 @@ The following options are used to configure the component:
 | `runtime.namespace`          | namespace to use for the runtime (only for kubernetes)                                          | `false`  | `N/A`                    | `RUNTIME_NAMESPACE`<br>`VELA_RUNTIME_NAMESPACE`                   |
 | `runtime.pods-template-name` | name of the PipelinePodsTemplate to retrieve from the `runtime.namespace` (only for kubernetes) | `false`  | `N/A`                    | `RUNTIME_PODS_TEMPLATE_NAME`<br>`VELA_RUNTIME_PODS_TEMPLATE_NAME` |
 | `runtime.pods-template-file` | path to local fallback file containing a PipelinePodsTemplate in YAML (only for kubernetes)     | `false`  | `N/A`                    | `RUNTIME_PODS_TEMPLATE_FILE`<br>`VELA_RUNTIME_PODS_TEMPLATE_FILE` |
-| `runtime.privileged-images`  | images allowed to run in privileged mode for the runtime                                        | `false`  | `[ target/vela-docker ]` | `RUNTIME_PRIVILEGED_IMAGES`<br>`VELA_RUNTIME_PRIVILEGED_IMAGES`   |
+| `runtime.privileged-images`  | images allowed to run in privileged mode for the runtime                                        | `false`  | `[ ]` | `RUNTIME_PRIVILEGED_IMAGES`<br>`VELA_RUNTIME_PRIVILEGED_IMAGES`   |
 | `runtime.volumes`            | path to host volumes to mount into resources for the runtime                                    | `false`  | `N/A`                    | `RUNTIME_VOLUMES`<br>`VELA_RUNTIME_VOLUMES`                       |
 
 {{% alert title="Note:" color="primary" %}}

--- a/content/reference/yaml/steps.md
+++ b/content/reference/yaml/steps.md
@@ -33,10 +33,8 @@ steps:
 | `commands`    | N        | []string        | Execution instructions to run inside the container.              |
 | `template`    | N        | struct          | Name of a template to expand in the pipeline.                      |
 | `entrypoint`  | N        | []string        | Commands to execute inside the container.                        |
-| `detach`      | N        | []string        | Run the container in a detached (headless) state.                |
-| `volume`      | N        | string          | Mount volumes for the container.                                 |
-| `ulimits`     | N        | string          | Set the user limits for the container.                           |
-| `privileged`  | N        | string          | Run the container with extra privileges.                         |
+| `detach`      | N        | []string        | Run the container in a detached (headless) state.                |                                |
+| `ulimits`     | N        | string          | Set the user limits for the container.                           |                        |
 | `user`        | N        | string          | Set the user for the container. |
 
 
@@ -358,30 +356,6 @@ steps:
   - detach: true
 ```
 
-#### The `volume:` tag
-
-```yaml
----
-steps:
-    # Mount volumes for the container.
-  - volume:
-      - source: /foo
-
-      - source: /foo
-        destination: /bar
-
-      - source: /foo
-        destination: /foobar
-        access_mode: ro
-```
-
-```yaml
----
-steps:
-    # Mount volumes for the container.
-  - volume: [ /foo, /foo:/bar, /foo:/foobar:ro ]
-```
-
 #### The `ulimits:` tag
 
 ```yaml
@@ -394,15 +368,6 @@ steps:
       - name: bar
         soft: 1024
         hard: 2048
-```
-
-#### The `privileged:` tag
-
-```yaml
----
-steps:
-    # Run the container with extra privileges.
-  - privileged: true
 ```
 
 #### The `user:` tag


### PR DESCRIPTION
Related to changes here: https://github.com/go-vela/worker/pull/391 + https://github.com/go-vela/server/pull/724

Also removing `volumes` and `privileged` tag documentation, since that doesn't actually work and is configured via platform start up.