### PR TITLE
chore(templates): add docs for file type template usage

### DIFF
--- a/content/reference/yaml/templates.md
+++ b/content/reference/yaml/templates.md
@@ -53,12 +53,26 @@ templates:
     source: github.com/go-vela/templates/example.yml@testbranch
 ```
 
+```yaml
+templates:
+    # As an alternative, if the template is within the same repository,
+    # the source can be the path to the template in the Vela workspace.
+    # This is used in conjunction with `type: file`.
+    source: path/to/template.yml
+```
+
 #### The `type:` tag
 
 ```yaml
 templates:
     # Indicates to the compiler which version to use.
     type: github
+```
+
+```yaml
+templates:
+    # The 'file' type will grab a template from the repository on a commit.
+    type: file
 ```
 
 #### The `format:` tag


### PR DESCRIPTION
Adding some docs in the yaml reference for the new type of template usage.

Ref: https://github.com/go-vela/server/pull/713