### PR TITLE
enhance(ci): update deps and use token for plugin docs shortcode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,11 @@ on:
 # pipeline to execute
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
     - name: clone
       uses: actions/checkout@v3
@@ -20,17 +24,18 @@ jobs:
     - name: node
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: hugo
       uses: peaceiris/actions-hugo@v2
       with:
-        hugo-version: '0.101.0'
+        hugo-version: '0.108.0'
         extended: true
 
     - name: build
       env:
         HUGO_ENV: production
+        HUGO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         npm install -D --save autoprefixer
         npm install -D --save postcss-cli

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,12 @@ on:
 # pipeline to execute
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pages: write
+
     steps:
     - name: clone
       uses: actions/checkout@v3
@@ -21,17 +26,18 @@ jobs:
     - name: node
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: hugo
       uses: peaceiris/actions-hugo@v2
       with:
-        hugo-version: '0.101.0'
+        hugo-version: '0.108.0'
         extended: true
 
     - name: build
       env:
         HUGO_ENV: production
+        HUGO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         npm install -D --save autoprefixer
         npm install -D --save postcss-cli

--- a/layouts/shortcodes/plugin-docs.html
+++ b/layouts/shortcodes/plugin-docs.html
@@ -1,4 +1,44 @@
+{{/*
+  assign the passed in parameters
+*/}}
+
 {{ $repo := .Get 0 }}
 {{ $filename := .Get 1 }}
-{{ $json := getJSON "https://api.github.com/repos/" $repo "/contents/" $filename }}
-{{ $json.content | base64Decode | markdownify | emojify }}
+{{ $version := .Get 2 | default "main" }}
+
+
+{{/*
+ construct the url 
+*/}}
+
+{{ $docsURL := printf "https://api.github.com/repos/%s/contents/%s?ref=%s" $repo $filename $version }}
+{{ $dataJSON := false }}
+
+
+{{/*
+  utilize HUGO_GITHUB_TOKEN to avoid rate limit issues  
+*/}}
+
+{{ with $github_token := (os.Getenv "HUGO_GITHUB_TOKEN" | default false ) }}
+  {{ $bearer_token := dict "Authorization" (printf "Bearer %s" .) }}
+  {{ $dataJSON = getJSON $docsURL $bearer_token }}
+{{ else }}
+  {{ $dataJSON = getJSON $docsURL }}
+{{ end }}
+
+
+{{/*
+  if we have data, render it.
+  otherwise, render a helpful message.
+*/}}
+
+{{ with $dataJSON }}
+  {{ .content | base64Decode | markdownify | emojify }}
+{{ else }}
+  {{ $docsPage := printf "https://github.com/%s/blob/%s/%s" $repo $version $filename }}
+  <div class="alert alert-warning" role="alert">
+    <h4 class="alert-heading">Warning</h4>
+    <p>There was an error inlining the documentation.</p>
+    <p>Please visit <a href="{{ $docsPage }}">{{ $repo }} documentation</a> to learn more about this plugin.</p>
+  </div>
+{{ end }}


### PR DESCRIPTION
we are utilizing a custom Hugo shortcode to emded documentation from other repositories to maintain one source of truth. The current implementation can run into an issue with rate limiting as it makes anonymous requests to the other repositories.

with these changes, those requests should now utilize a token and prevent rate limit issues. it also adds the ability (currently unused) to pin documentation to certain versions/tags. for example:

pull from `main` (default):
```
{{% plugin-docs "go-vela/vela-ansible" "DOCS.md" %}}
```

pull from `v0.1.0`:
```
{{% plugin-docs "go-vela/vela-ansible" "DOCS.md" "v0.1.0" %}}
```

as a fallback, if it can't pull the documentation it will render a warning on the plugin page with a link to the respective documentation that folks can use instead.

the PR also updates Hugo, Node, and Ubuntu versions.