### PR TITLE
feat: add information for schedules

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -27,7 +27,7 @@ Please see our [support](SUPPORT.md) documentation for further instructions.
 ## Copyright and License
 
 ```
-Copyright (c) 2022 Target Brands, Inc.
+Copyright (c) 2023 Target Brands, Inc.
 ```
 
 [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2022 Target Brands, Inc.
+   Copyright (c) 2023 Target Brands, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/content/installation/server/reference/_index.md
+++ b/content/installation/server/reference/_index.md
@@ -442,6 +442,26 @@ The variable can be provided as a comma-separated `list` (i.e. `myOrg1/myRepo1,m
 By default, no repositories are allowed to be enabled. To allow any repository to be enabled, provide a single value of `*`.
 {{% /alert %}}
 
+### VELA_SCHEDULE_ALLOWLIST
+
+This variable sets a group of repositories, from the SCM, that can create a schedule for a repo on the server.
+
+The variable can be provided as a comma-separated `list` (i.e. `myOrg1/myRepo1,myOrg1/myRepo2,myOrg2/*`).
+
+{{% alert title="Note:" color="primary" %}}
+By default, no repositories are allowed to create a schedule. To allow any repository to create a schedule, provide a single value of `*`.
+{{% /alert %}}
+
+### VELA_SCHEDULE_MINIMUM_FREQUENCY
+
+This variable sets the minimum frequency allowed to be set for a schedule.
+
+The variable can be provided as a `duration` (i.e. `5s`, `10m`).
+
+{{% alert title="Note:" color="primary" %}}
+This variable has a default value of `1h`.
+{{% /alert %}}
+
 ### VELA_SCM_ADDR
 
 This configuration variable is used by the [SCM component](/docs/installation/server/reference/scm/) for the server.

--- a/content/reference/api/schedule/_index.md
+++ b/content/reference/api/schedule/_index.md
@@ -1,0 +1,14 @@
+---
+title: "Schedule"
+linkTitle: "Schedule"
+description: >
+  Learn how to use API endpoints for the schedule resource.
+---
+
+The below endpoints are available to operate on the `schedule` resource.
+
+{{% alert color="warning" %}}
+This section assumes you already know how to authenticate to the API.
+
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
+{{% /alert %}}

--- a/content/reference/api/schedule/add.md
+++ b/content/reference/api/schedule/add.md
@@ -1,0 +1,78 @@
+---
+title: "Add"
+linkTitle: "Add"
+description: >
+  Learn how to create a schedule.
+---
+
+## Endpoint
+
+```
+POST  /api/v1/schedules/:org/:repo
+```
+
+## Parameters
+
+The following parameters are used to configure the endpoint:
+
+| Name   | Description          |
+|--------|----------------------|
+| `org`  | name of organization |
+| `repo` | name of repository   |
+
+## Permissions
+
+COMING SOON!
+
+## Responses
+
+| Status Code | Description                                         |
+|-------------|-----------------------------------------------------|
+| `200`       | indicates the request has succeeded                 |
+| `401`       | indicates the user does not have proper permissions |
+
+## Sample
+
+{{% alert color="warning" %}}
+This section assumes you already know how to authenticate to the API.
+
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
+{{% /alert %}}
+
+#### File
+
+```json
+{
+  "name": "hourly",
+  "entry": "0 * * * *",
+  "active": true
+}
+```
+
+#### Request
+
+```sh
+curl \
+  -X POST \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d "@data.json" \
+  "http://127.0.0.1:8080/api/v1/schedules/github/octocat"
+```
+
+#### Response
+
+```json
+{
+  "id": 1,
+  "repo_id": 1,
+  "active": true,
+  "name": "hourly",
+  "entry": "0 * * * *",
+  "created_at": 1641314085,
+  "created_by": "octokitty",
+  "updated_at": 1641314085,
+  "updated_by": "octokitty",
+  "scheduled_at": 0
+}
+```

--- a/content/reference/api/schedule/get.md
+++ b/content/reference/api/schedule/get.md
@@ -1,0 +1,83 @@
+---
+title: "Get"
+linkTitle: "Get"
+description: >
+  Learn how to list schedules.
+---
+
+## Endpoint
+
+```
+GET  /api/v1/schedules/:org/:repo
+```
+
+## Parameters
+
+The following parameters are used to configure the endpoint:
+
+| Name   | Description          |
+|--------|----------------------|
+| `org`  | name of organization |
+| `repo` | name of repository   |
+
+## Permissions
+
+COMING SOON!
+
+## Responses
+
+| Status Code | Description                                         |
+|-------------|-----------------------------------------------------|
+| `200`       | indicates the request has succeeded                 |
+| `400`       | unable to retrieve the schedules                    |
+| `401`       | indicates the user does not have proper permissions |
+| `404`       | unable to retrieve the schedules                    |
+| `500`       | system error while retrieving the schedules         |
+
+## Sample
+
+{{% alert color="warning" %}}
+This section assumes you already know how to authenticate to the API.
+
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
+{{% /alert %}}
+
+#### Request
+
+```sh
+curl \
+  -X GET \
+  -H "Authorization: Bearer <token>" \
+  "http://127.0.0.1:8080/api/v1/schedules/github/octocat"
+```
+
+#### Response
+
+```json
+[
+  {
+    "id": 2,
+    "repo_id": 1,
+    "active": true,
+    "name": "nightly",
+    "entry": "0 0 * * *",
+    "created_at": 1641314086,
+    "created_by": "octokitty",
+    "updated_at": 1641314086,
+    "updated_by": "octokitty",
+    "scheduled_at": 0
+  },
+  {
+    "id": 1,
+    "repo_id": 1,
+    "active": true,
+    "name": "hourly",
+    "entry": "0 * * * *",
+    "created_at": 1641314085,
+    "created_by": "octokitty",
+    "updated_at": 1641314085,
+    "updated_by": "octokitty",
+    "scheduled_at": 0
+  }
+]
+```

--- a/content/reference/api/schedule/remove.md
+++ b/content/reference/api/schedule/remove.md
@@ -1,0 +1,56 @@
+---
+title: "Remove"
+linkTitle: "Remove"
+description: >
+  Learn how to delete a schedule.
+---
+
+## Endpoint
+
+```
+DELETE  /api/v1/schedules/:org/:repo/:schedule
+```
+
+## Parameters
+
+The following parameters are used to configure the endpoint:
+
+| Name       | Description                      |
+|------------|----------------------------------|
+| `org`      | name of organization             |
+| `repo`     | name of repository               |
+| `schedule` | name of schedule from repository |
+
+## Permissions
+
+COMING SOON!
+
+## Responses
+
+| Status Code | Description                                         |
+|-------------|-----------------------------------------------------|
+| `200`       | indicates the request has succeeded                 |
+| `401`       | indicates the user does not have proper permissions |
+
+## Sample
+
+{{% alert color="warning" %}}
+This section assumes you already know how to authenticate to the API.
+
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
+{{% /alert %}}
+
+#### Request
+
+```sh
+curl \
+  -X DELETE \
+  -H "Authorization: Bearer <token>" \
+  "http://127.0.0.1:8080/api/v1/schedules/github/octocat/hourly"
+```
+
+#### Response
+
+```sh
+schedule "hourly" deleted
+```

--- a/content/reference/api/schedule/update.md
+++ b/content/reference/api/schedule/update.md
@@ -1,0 +1,77 @@
+---
+title: "Update"
+linkTitle: "Update"
+description: >
+  Learn how to modify a schedule.
+---
+
+## Endpoint
+
+```
+PUT  /api/v1/schedules/:org/:repo/:schedule
+```
+
+## Parameters
+
+The following parameters are used to configure the endpoint:
+
+| Name       | Description                      |
+|------------|----------------------------------|
+| `org`      | name of organization             |
+| `repo`     | name of repository               |
+| `schedule` | name of schedule from repository |
+
+## Permissions
+
+COMING SOON!
+
+## Responses
+
+| Status Code | Description                                         |
+|-------------|-----------------------------------------------------|
+| `200`       | indicates the request has succeeded                 |
+| `401`       | indicates the user does not have proper permissions |
+
+## Sample
+
+{{% alert color="warning" %}}
+This section assumes you already know how to authenticate to the API.
+
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
+{{% /alert %}}
+
+#### File
+
+```json
+{
+  "active": false
+}
+```
+
+#### Request
+
+```sh
+curl \
+  -X PUT \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d "@data.json" \
+  "http://127.0.0.1:8080/api/v1/schedules/github/octocat/hourly"
+```
+
+#### Response
+
+```json
+{
+  "id": 1,
+  "repo_id": 1,
+  "active": false,
+  "name": "hourly",
+  "entry": "0 * * * *",
+  "created_at": 1641314085,
+  "created_by": "octokitty",
+  "updated_at": 1641314086,
+  "updated_by": "octokitty",
+  "scheduled_at": 0
+}
+```

--- a/content/reference/api/schedule/view.md
+++ b/content/reference/api/schedule/view.md
@@ -1,0 +1,69 @@
+---
+title: "View"
+linkTitle: "View"
+description: >
+  Learn how to inspect a schedule.
+---
+
+## Endpoint
+
+```
+GET  /api/v1/schedules/:org/:repo/:schedule
+```
+
+## Parameters
+
+The following parameters are used to configure the endpoint:
+
+| Name       | Description                      |
+|------------|----------------------------------|
+| `org`      | name of organization             |
+| `repo`     | name of repository               |
+| `schedule` | name of schedule from repository |
+
+## Permissions
+
+COMING SOON!
+
+## Responses
+
+| Status Code | Description                                         |
+|-------------|-----------------------------------------------------|
+| `200`       | indicates the request has succeeded                 |
+| `400`       | unable to retrieve the schedule                     |
+| `401`       | indicates the user does not have proper permissions |
+| `404`       | unable to retrieve the schedule                     |
+
+## Sample
+
+{{% alert color="warning" %}}
+This section assumes you already know how to authenticate to the API.
+
+To authenticate to the API, please review the [authentication documentation](/docs/reference/api/authentication/).
+{{% /alert %}}
+
+#### Request
+
+```sh
+curl \
+  -X GET \
+  -H "Authorization: Bearer <token>" \
+  "http://127.0.0.1:8080/api/v1/schedules/github/octocat/hourly"
+```
+
+#### Response
+
+```json
+{
+  "id": 1,
+  "repo_id": 1,
+  "active": true,
+  "name": "hourly",
+  "entry": "0 * * * *",
+  "created_at": 1641314085,
+  "created_by": "octokitty",
+  "updated_at": 1641314085,
+  "updated_by": "octokitty",
+  "scheduled_at": 0
+}
+```

--- a/content/reference/cli/schedule/_index.md
+++ b/content/reference/cli/schedule/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Schedule"
+linkTitle: "Schedule"
+description: >
+  Learn how to use CLI commands for the schedule resource.
+---
+
+The below commands are available to operate on the `schedule` resource.
+
+{{% alert color="warning" %}}
+This section assumes you have already installed and setup the CLI.
+
+To install the CLI, please review the [installation documentation](/docs/reference/cli/install/).
+
+To setup the CLI, please review the [authentication documentation](/docs/reference/cli/authentication/).
+{{% /alert %}}

--- a/content/reference/cli/schedule/add.md
+++ b/content/reference/cli/schedule/add.md
@@ -1,0 +1,93 @@
+---
+title: "Add"
+linkTitle: "Add"
+description: >
+  Learn how to create a schedule.
+---
+
+## Command
+
+```
+$ vela add schedule <parameters...> <arguments...>
+```
+
+{{% alert color="info" %}}
+For more information, you can run `vela add schedule --help`.
+{{% /alert %}}
+
+## Parameters
+
+The following parameters are used to configure the command:
+
+| Name       | Description                           | Environment Variables            |
+|------------|---------------------------------------|----------------------------------|
+| `org`      | name of organization for the schedule | `VELA_ORG`, `SCHEDULE_ORG`       |
+| `repo`     | name of repository for the schedule   | `VELA_REPO`, `SCHEDULE_REPO`     |
+| `schedule` | name of the schedule                  | `VELA_SCHEDULE`, `SCHEDULE_NAME` |
+| `entry`    | frequency for the schedule            | `VELA_ENTRY`, `SCHEDULE_ENTRY`   |
+| `active`   | enables/disables the schedule         | `VELA_ACTIVE`, `SCHEDULE_ACTIVE` |
+| `output`   | format the output for the schedule    | `VELA_OUTPUT`, `SCHEDULE_OUTPUT` |
+
+{{% alert color="info" %}}
+This command also supports setting the following parameters via a configuration file:
+
+- `org`
+- `repo`
+- `output`
+
+For more information, please review the [CLI config documentation](/docs/reference/cli/config/).
+{{% /alert %}}
+
+## Sample
+
+{{% alert color="warning" %}}
+This section assumes you have already installed and setup the CLI.
+
+To install the CLI, please review the [installation documentation](/docs/reference/cli/install/).
+
+To setup the CLI, please review the [authentication documentation](/docs/reference/cli/authentication/).
+{{% /alert %}}
+
+#### Request
+
+```sh
+$ pwd
+~/github/octocat
+$ vela add schedule --schedule hourly --entry '0 * * * *'
+```
+
+#### Targeted Request
+
+```sh
+$ vela add schedule --org github --repo octocat --schedule hourly --entry '0 * * * *'
+```
+
+#### Response
+```sh
+{
+  Active: true,
+  CreatedAt: 1641314085,
+  CreatedBy: octokitty,
+  Entry: 0 * * * *,
+  ID: 1,
+  Name: hourly,
+  RepoID: 1,
+  ScheduledAt: 0,
+  UpdatedAt: 1641314085,
+  UpdatedBy: octokitty,
+}
+```
+
+## Examples
+
+```sh
+EXAMPLES:
+  1. Add a schedule to a repository with active not enabled.
+    $ vela add schedule --org MyOrg --repo MyRepo --schedule hourly --entry '0 * * * *' --active false
+  2. Add a schedule to a repository with a nightly entry.
+    $ vela add schedule --org MyOrg --repo MyRepo --schedule nightly --entry '0 0 * * *'
+  3. Add a schedule to a repository with a weekly entry.
+    $ vela add schedule --org MyOrg --repo MyRepo --schedule weekly --entry '@weekly'
+  4. Add a schedule to a repository when config or environment variables are set.
+    $ vela add schedule
+```

--- a/content/reference/cli/schedule/get.md
+++ b/content/reference/cli/schedule/get.md
@@ -1,0 +1,85 @@
+---
+title: "Get"
+linkTitle: "Get"
+description: >
+  Learn how to list schedules.
+---
+
+## Command
+
+```
+$ vela get schedule <parameters...> <arguments...>
+```
+
+{{% alert color="info" %}}
+For more information, you can run `vela get schedule --help`.
+{{% /alert %}}
+
+## Parameters
+
+The following parameters are used to configure the command:
+
+| Name       | Description                            | Environment Variables                |
+|------------|----------------------------------------|--------------------------------------|
+| `org`      | name of organization for the schedules | `VELA_ORG`, `SCHEDULE_ORG`           |
+| `repo`     | name of repository for the schedules   | `VELA_REPO`, `SCHEDULE_REPO`         |
+| `output`   | format the output for the schedules    | `VELA_OUTPUT`, `SCHEDULE_OUTPUT`     |
+| `page`     | prints a specific page of schedules    | `VELA_PAGE`, `SCHEDULE_PAGE`         |
+| `per.page` | number of schedules to print per page  | `VELA_PER_PAGE`, `SCHEDULE_PER_PAGE` |
+
+{{% alert color="info" %}}
+This command also supports setting the following parameters via a configuration file:
+
+- `org`
+- `repo`
+- `output`
+
+For more information, please review the [CLI config documentation](/docs/reference/cli/config/).
+{{% /alert %}}
+
+## Sample
+
+{{% alert color="warning" %}}
+This section assumes you have already installed and setup the CLI.
+
+To install the CLI, please review the [installation documentation](/docs/reference/cli/install/).
+
+To setup the CLI, please review the [authentication documentation](/docs/reference/cli/authentication/).
+{{% /alert %}}
+
+#### Request
+
+```sh
+$ pwd
+~/github/octocat
+$ vela get schedule
+```
+
+#### Targeted Request
+
+```sh
+$ vela get schedule --org github --repo octocat
+```
+
+#### Response
+```sh
+NAME   	ENTRY    	ACTIVE	SCHEDULED_AT
+nightly	0 0 * * *	true  	a second ago
+hourly 	0 * * * *	true  	a second ago
+```
+
+## Examples
+
+```sh
+EXAMPLES:
+  1. Get a list of schedules for a repository.
+    $ vela get schedule --org MyOrg --repo MyRepo
+  2. Get a list of schedules for a repository with wide view output.
+    $ vela get schedule --org MyOrg --repo MyRepo --output wide
+  3. Get a list of schedules for a repository with yaml output.
+    $ vela get schedule --org MyOrg --repo MyRepo --output yaml
+  4. Get a list of schedules for a repository with json output.
+    $ vela get schedule --org MyOrg --repo MyRepo --output json
+  5. Get a list of schedules for a repository when config or environment variables are set.
+    $ vela get schedule
+```

--- a/content/reference/cli/schedule/remove.md
+++ b/content/reference/cli/schedule/remove.md
@@ -1,0 +1,85 @@
+---
+title: "Remove"
+linkTitle: "Remove"
+description: >
+  Learn how to delete a schedule.
+---
+
+## Command
+
+```
+$ vela remove schedule <parameters...> <arguments...>
+```
+
+{{% alert color="info" %}}
+For more information, you can run `vela remove schedule --help`.
+{{% /alert %}}
+
+## Parameters
+
+The following parameters are used to configure the command:
+
+| Name       | Description                           | Environment Variables            |
+|------------|---------------------------------------|----------------------------------|
+| `org`      | name of organization for the schedule | `VELA_ORG`, `SCHEDULE_ORG`       |
+| `repo`     | name of repository for the schedule   | `VELA_REPO`, `SCHEDULE_REPO`     |
+| `schedule` | name of the schedule                  | `VELA_SCHEDULE`, `SCHEDULE_NAME` |
+| `output`   | format the output for the schedule    | `VELA_OUTPUT`, `SCHEDULE_OUTPUT` |
+
+{{% alert color="info" %}}
+This command also supports setting the following parameters via a configuration file:
+
+- `org`
+- `repo`
+- `output`
+
+For more information, please review the [CLI config documentation](/docs/reference/cli/config/).
+{{% /alert %}}
+
+## Permissions
+
+COMING SOON!
+
+## Sample
+
+{{% alert color="warning" %}}
+This section assumes you have already installed and setup the CLI.
+
+To install the CLI, please review the [installation documentation](/docs/reference/cli/install/).
+
+To setup the CLI, please review the [authentication documentation](/docs/reference/cli/authentication/).
+{{% /alert %}}
+
+#### Request
+
+```sh
+$ pwd
+~/github/octocat
+$ vela remove schedule --schedule hourly 
+```
+
+#### Targeted Request
+
+```sh
+$ pwd
+~/github/octocat
+$ vela remove schedule --org github --repo octocat --schedule hourly 
+```
+
+#### Response
+
+```sh
+schedule "hourly" was deleted
+```
+
+## Examples
+
+```sh
+EXAMPLES:
+  1. Remove a schedule from a repository.
+    $ vela remove schedule --org MyOrg --repo MyRepo --schedule daily
+  2. Remove a schedule from a repository with json output.
+    $ vela remove schedule --org MyOrg --repo MyRepo --schedule daily --output json
+  3. Remove a schedule from a repository when config or environment variables are set.
+    $ vela remove schedule
+```

--- a/content/reference/cli/schedule/update.md
+++ b/content/reference/cli/schedule/update.md
@@ -1,0 +1,96 @@
+---
+title: "Update"
+linkTitle: "Update"
+description: >
+  Learn how to modify a schedule.
+---
+
+## Command
+
+```
+$ vela update schedule <parameters...> <arguments...>
+```
+
+{{% alert color="info" %}}
+For more information, you can run `vela update schedule --help`.
+{{% /alert %}}
+
+## Parameters
+
+The following parameters are used to configure the command:
+
+| Name       | Description                           | Environment Variables            |
+|------------|---------------------------------------|----------------------------------|
+| `org`      | name of organization for the schedule | `VELA_ORG`, `SCHEDULE_ORG`       |
+| `repo`     | name of repository for the schedule   | `VELA_REPO`, `SCHEDULE_REPO`     |
+| `schedule` | name of the schedule                  | `VELA_SCHEDULE`, `SCHEDULE_NAME` |
+| `entry`    | frequency for the schedule            | `VELA_ENTRY`, `SCHEDULE_ENTRY`   |
+| `active`   | enables/disables the schedule         | `VELA_ACTIVE`, `SCHEDULE_ACTIVE` |
+| `output`   | format the output for the schedule    | `VELA_OUTPUT`, `SCHEDULE_OUTPUT` |
+
+{{% alert color="info" %}}
+This command also supports setting the following parameters via a configuration file:
+
+- `org`
+- `repo`
+- `output`
+
+For more information, please review the [CLI config documentation](/docs/reference/cli/config/).
+{{% /alert %}}
+
+## Permissions
+
+COMING SOON!
+
+## Sample
+
+{{% alert color="warning" %}}
+This section assumes you have already installed and setup the CLI.
+
+To install the CLI, please review the [installation documentation](/docs/reference/cli/install/).
+
+To setup the CLI, please review the [authentication documentation](/docs/reference/cli/authentication/).
+{{% /alert %}}
+
+#### Request
+
+```sh
+$ pwd
+~/github/octocat
+$ vela update schedule --name hourly --active false
+```
+
+#### Targeted Request
+
+```sh
+$ vela update schedule --org github --repo octocat --name hourly --active false
+```
+
+#### Response
+
+```sh
+{
+  Active: false,
+  CreatedAt: 1641314085,
+  CreatedBy: octokitty,
+  Entry: 0 * * * *,
+  ID: 1,
+  Name: hourly,
+  RepoID: 1,
+  ScheduledAt: 0,
+  UpdatedAt: 1641314086,
+  UpdatedBy: octokitty,
+}
+```
+
+## Examples
+
+```sh
+EXAMPLES:
+  1. Update a schedule for a repository with active disabled.
+    $ vela update schedule --org MyOrg --repo MyRepo --schedule hourly --active false
+  2. Update a schedule for a repository with a new entry.
+    $ vela update schedule --org MyOrg --repo MyRepo --schedule nightly --entry '@nightly'
+  3. Update a schedule for a repository when config or environment variables are set.
+    $ vela update schedule
+```

--- a/content/reference/cli/schedule/view.md
+++ b/content/reference/cli/schedule/view.md
@@ -1,0 +1,89 @@
+---
+title: "View"
+linkTitle: "View"
+description: >
+  Learn how to inspect a schedule.
+---
+
+## Command
+
+```
+$ vela view schedule <parameters...> <arguments...>
+```
+
+{{% alert color="info" %}}
+For more information, you can run `vela view schedule --help`.
+{{% /alert %}}
+
+## Parameters
+
+The following parameters are used to configure the command:
+
+| Name       | Description                           | Environment Variables            |
+|------------|---------------------------------------|----------------------------------|
+| `org`      | name of organization for the schedule | `VELA_ORG`, `SCHEDULE_ORG`       |
+| `repo`     | name of repository for the schedule   | `VELA_REPO`, `SCHEDULE_REPO`     |
+| `schedule` | name of the schedule                  | `VELA_SCHEDULE`, `SCHEDULE_NAME` |
+| `output`   | format the output for the schedule    | `VELA_OUTPUT`, `SCHEDULE_OUTPUT` |
+
+{{% alert color="info" %}}
+This command also supports setting the following parameters via a configuration file:
+
+- `org`
+- `repo`
+- `output`
+
+For more information, please review the [CLI config documentation](/docs/reference/cli/config/).
+{{% /alert %}}
+
+## Sample
+
+{{% alert color="warning" %}}
+This section assumes you have already installed and setup the CLI.
+
+To install the CLI, please review the [installation documentation](/docs/reference/cli/install/).
+
+To setup the CLI, please review the [authentication documentation](/docs/reference/cli/authentication/).
+{{% /alert %}}
+
+#### Request
+
+```sh
+$ pwd
+~/github/octocat
+$ vela view schedule --schedule hourly
+```
+
+#### Targeted Request
+
+```sh
+$ vela view schedule --org github --repo octocat --schedule hourly
+```
+
+#### Response
+```sh
+{
+  Active: true,
+  CreatedAt: 1641314085,
+  CreatedBy: octokitty,
+  Entry: 0 * * * *,
+  ID: 1,
+  Name: hourly,
+  RepoID: 1,
+  ScheduledAt: 0,
+  UpdatedAt: 1641314085,
+  UpdatedBy: octokitty,
+}
+```
+
+## Examples
+
+```sh
+EXAMPLES:
+  1. View details of a schedule for a repository.
+    $ vela view schedule --org MyOrg --repo MyRepo --schedule hourly
+  2. View details of a schedule for a repository with json output.
+    $ vela view schedule --org MyOrg --repo MyRepo --schedule hourly --output json
+  3. View details of a schedule for a repository when config or environment variables are set.
+    $ vela view schedule
+```

--- a/content/reference/yaml/steps.md
+++ b/content/reference/yaml/steps.md
@@ -117,16 +117,16 @@ steps:
 
 The following rules can be used to configure a ruleset:
 
-| Name      | Description                            |
-|-----------|----------------------------------------|
-| `branch`  | name of branch for a build.            |
-| `comment` | pull request comment body.             |
-| `event`   | name of an event for a build.          |
-| `path`    | path to workspace files for a build.   |
-| `repo`    | name of the  repo for a build.         |
-| `status`  | name of status for a build.            |
-| `tag`     | name of reference for a build.         |
-| `target`  | name of deployment target for a build. |
+| Name      | Description                                        |
+|-----------|----------------------------------------------------|
+| `branch`  | name of branch for a build.                        |
+| `comment` | pull request comment body.                         |
+| `event`   | name of an event for a build.                      |
+| `path`    | path to workspace files for a build.               |
+| `repo`    | name of the  repo for a build.                     |
+| `status`  | name of status for a build.                        |
+| `tag`     | name of reference for a build.                     |
+| `target`  | name of deployment or schedule target for a build. |
 
 ```yaml
 ---
@@ -207,7 +207,7 @@ steps:
 steps:
   - ruleset:
       # As shown below this step will execute if the build target is stage or production.
-      # This tag is only compatible with deployment events.
+      # This tag is only compatible with deployment and schedule events.
       target: [ dev/*, test/* ]
 ```
 

--- a/content/usage/schedule_build.md
+++ b/content/usage/schedule_build.md
@@ -1,0 +1,86 @@
+---
+title: "Scheduling a Build"
+linkTitle: "Scheduling a Build"
+description: >
+  Schedule builds for your repo.
+---
+
+{{% alert title="Note:" color="primary" %}}
+Please ensure you've already [started a build]((/docs/usage/start_build/)) for your repo before attempting to setup a schedule.
+{{% /alert %}}
+
+Vela supports the ability to trigger builds for a repo on a cadence known as a "schedule".
+
+Outside of the Vela ecosystem, this is more commonly known as a [cron expression](https://en.wikipedia.org/wiki/Cron).
+
+Users will be able to manage schedules for a repo via the UI, [API](/docs/reference/api/schedule/) and [CLI](/docs/reference/api/schedule/).
+
+Only users with `admin` access to a repo will be able to manage schedules for that repo.
+
+{{% alert title="Warning:" color="primary" %}}
+We make best efforts to support feature parity with `cron` but we may not support every capability.
+{{% /alert %}}
+
+## Entry
+
+Users will be able to customize the cadence or frequency for how often the schedule should trigger a build via the `entry` field.
+
+Here's a small list of examples to demonstrate valid values for this field:
+
+* `0 * * * *` - setup a schedule to run every hour
+* `0 0 * * *` - setup a schedule to run every day at midnight
+* `0 0 * * 0` - setup a schedule to run every week on Sunday at midnight
+
+Vela currently uses [github.com/adhocore/gronx](https://github.com/adhocore/gronx) to parse and validate this field.
+
+This library also supports a number of "common" cron expressions (a.k.a. "tags") i.e. `@hourly`, `@daily`, `@weekly` etc.
+
+For more information, please see that library's [official docs for these tags](https://github.com/adhocore/gronx#tags).
+
+{{% alert title="Tip:" color="primary" %}}
+We recommend leveraging an official cron expression generator like [Crontab Guru](https://crontab.guru/) to build the `entry` for your schedule.
+{{% /alert %}}
+
+## Pipeline
+
+Uses will be able to customize what [stages](/docs/tour/stages/) or [steps](/docs/tour/steps/) will run in a build for a schedule using a [ruleset](/docs/tour/rulesets/):
+
+```yaml
+version: "1"
+
+steps:
+  - name: unit-test
+    ruleset:
+      event: [ deployment, schedule ]
+      target: [ unit_test, integration_test, nightly ]
+    commands:
+      - echo "I run when a schedule with the name 'unit_test', 'integration_test' or 'nightly' is executed"
+
+  - name: integration-test
+    ruleset:
+      event: [ deployment, schedule ]
+      target: [ integration_test, nightly ]
+    commands:
+      - echo "I run when a schedule with the name 'integration_test' or 'nightly' is executed"
+      
+  - name: publish
+    ruleset:
+      event: [ deployment, schedule ]
+      target: [ nightly ]
+    commands:
+      - echo "I run when a schedule with the name 'nightly' is executed"
+      
+  - name: notification
+    ruleset:
+      event: [ deployment, schedule ]
+    commands:
+      - echo "I run when any schedule is executed"
+```
+
+{{% alert title="Tip:" color="primary" %}}
+We recommend adding the `deployment` event to your `ruleset` for processes that you want to run on a schedule.
+
+This will enable you to manually trigger a build once that replicates the configuration you want to run on a schedule.
+
+This is especially useful when attempting to initially test and debug your pipeline for a schedule.
+{{% /alert %}}

--- a/content/usage/schedule_build.md
+++ b/content/usage/schedule_build.md
@@ -6,10 +6,10 @@ description: >
 ---
 
 {{% alert title="Note:" color="primary" %}}
-Please ensure you've already [started a build]((/docs/usage/start_build/)) for your repo before attempting to setup a schedule.
+Please ensure you've already [started a build](/docs/usage/start_build/) for your repo before attempting to setup a schedule.
 {{% /alert %}}
 
-Vela supports the ability to trigger builds for a repo on a cadence known as a "schedule".
+Vela supports the ability to periodically trigger builds for a repo known as a "schedule".
 
 Outside of the Vela ecosystem, this is more commonly known as a [cron expression](https://en.wikipedia.org/wiki/Cron).
 
@@ -33,7 +33,7 @@ Here's a small list of examples to demonstrate valid values for this field:
 
 Vela currently uses [github.com/adhocore/gronx](https://github.com/adhocore/gronx) to parse and validate this field.
 
-This library also supports a number of "common" cron expressions (a.k.a. "tags") i.e. `@hourly`, `@daily`, `@weekly` etc.
+This library also supports a number of "common cron expressions" (a.k.a. "tags") i.e. `@hourly`, `@daily`, `@weekly` etc.
 
 For more information, please see that library's [official docs for these tags](https://github.com/adhocore/gronx#tags).
 
@@ -80,7 +80,7 @@ steps:
 {{% alert title="Tip:" color="primary" %}}
 We recommend adding the `deployment` event to your `ruleset` for processes that you want to run on a schedule.
 
-This will enable you to manually trigger a build once that replicates the configuration you want to run on a schedule.
+This will enable you to manually trigger a build that replicates the configuration you want to run on a schedule.
 
 This is especially useful when attempting to initially test and debug your pipeline for a schedule.
 {{% /alert %}}

--- a/content/usage/schedule_build.md
+++ b/content/usage/schedule_build.md
@@ -25,6 +25,10 @@ We make best efforts to support feature parity with `cron` but we may not suppor
 
 Users will be able to customize the cadence or frequency for how often the schedule should trigger a build via the `entry` field.
 
+By default, Vela sets a frequency limit of `1h` which controls the smallest amount of time a schedule can wait before running.
+
+i.e. A schedule can't trigger a build more often than every hour but this may be different for the Vela installation you use.
+
 Here's a small list of examples to demonstrate valid values for this field:
 
 * `0 * * * *` - setup a schedule to run every hour

--- a/content/usage/schedule_build.md
+++ b/content/usage/schedule_build.md
@@ -13,7 +13,7 @@ Vela supports the ability to periodically trigger builds for a repo known as a "
 
 Outside of the Vela ecosystem, this is more commonly known as a [cron expression](https://en.wikipedia.org/wiki/Cron).
 
-Users will be able to manage schedules for a repo via the UI, [API](/docs/reference/api/schedule/) and [CLI](/docs/reference/api/schedule/).
+Users will be able to manage schedules for a repo via the UI, [API](/docs/reference/api/schedule/) and [CLI](/docs/reference/cli/schedule/).
 
 Only users with `admin` access to a repo will be able to manage schedules for that repo.
 


### PR DESCRIPTION
closes: https://github.com/go-vela/community/issues/538

Part of https://github.com/go-vela/community/pull/772

This adds API, CLI and usage documentation for `schedules`.