### PR TITLE
chore(api/deploy): specify how parameters are passed into body

### DIFF
--- a/content/reference/api/deployment/add.md
+++ b/content/reference/api/deployment/add.md
@@ -74,3 +74,49 @@ curl \
   "description": "Deployment request from Vela"
 }
 ```
+
+#### File with Parameters
+
+If you would like to pass parameters, which can be referenced in the pipeline as `$DEPLOYMENT_PARAMETER_<KEY>`, include them as a map inside the `payload` tag.
+
+```json
+{
+  "ref": "main",
+  "target": "production",
+  "payload": {
+		"FIRST_EXAMPLE": "hello",
+		"SECOND_EXAMPLE": "goodbye"
+  }
+}
+```
+
+#### Request with Parameters
+
+```sh
+curl \
+  -X POST \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d "@data.json" \
+  "http://127.0.0.1:8080/api/v1/deployments/github/octocat"
+```
+
+#### Response with Parameters
+
+```json
+{
+  "id": 1,
+  "repo_id": 1,
+  "url": "https://api.github.com/repos/github/octocat/deployments/1",
+  "user": "octocat",
+  "commit": "48afb5bdc41ad69bf22588491333f7cf71135163",
+  "ref": "main",
+  "task": "deploy:vela",
+  "target": "production",
+  "description": "Deployment request from Vela",
+  "payload": {
+		"EXAMPLE": "hello",
+		"SECOND_EXAMPLE": "goodbye"
+  }
+}
+```


### PR DESCRIPTION
It isn't very clear that parameters are passed into the `payload` object, so I think this additional section could be helpful