### PR TITLE
enh(logging): add VELA_LOG_FORMATTER documentation

### DIFF
--- a/content/installation/server/reference/_index.md
+++ b/content/installation/server/reference/_index.md
@@ -330,6 +330,16 @@ This variable should only be used for local development.
 This variable has a default value of `true`.
 {{% /alert %}}
 
+### VELA_LOG_FORMATTER
+
+This variable sets whether the logging formatter used for structured server logs is a standard JSON logger, or a custom Elasticsearch Common Schema (ECS) compatible JSON formatter.
+
+The variable can be provided as a `string`.
+
+{{% alert title="Note:" color="primary" %}}
+This variable has a default value of `json`. Valid values are: `json`, and `ecs`.
+{{% /alert %}}
+
 ### VELA_MAX_BUILD_LIMIT
 
 This variable sets the maximum amount of concurrent builds a repo is allowed to run.

--- a/content/installation/server/reference/_index.md
+++ b/content/installation/server/reference/_index.md
@@ -97,18 +97,6 @@ The variable should be provided as a `string`.
 
 This section contains a list of all variables that can be provided to the server.
 
-### VELA_SECRET
-
-This variable sets a shared secret with the Vela [worker](/docs/installation/worker/) for authenticating communication between workers and the server.
-
-Only necessary to provide if utilizing the [server-worker trusted symmetric worker authentication method](/docs/installation/worker/docker/#worker-server-trusted-symmetric-token).
-
-The variable should be provided as a `string`.
-
-{{% alert title="Note:" color="primary" %}}
-This variable should match [the `VELA_SERVER_SECRET` variable](/docs/installation/worker/reference/#vela_server_secret) provided to the worker.
-{{% /alert %}}
-
 ### VELA_CLONE_IMAGE
 
 This configuration variable is used by the [compiler component](/docs/installation/server/reference/compiler) for the server.
@@ -546,6 +534,18 @@ The variable can be provided as a `string`.
 
 {{% alert title="Note:" color="primary" %}}
 This variable has a default value of [the `VELA_ADDR` variable](/docs/installation/server/reference/#vela_addr) provided to the server.
+{{% /alert %}}
+
+### VELA_SECRET
+
+This variable sets a shared secret with the Vela [worker](/docs/installation/worker/) for authenticating communication between workers and the server.
+
+Only necessary to provide if utilizing the [server-worker trusted symmetric worker authentication method](/docs/installation/worker/docker/#worker-server-trusted-symmetric-token).
+
+The variable should be provided as a `string`.
+
+{{% alert title="Note:" color="primary" %}}
+This variable should match [the `VELA_SERVER_SECRET` variable](/docs/installation/worker/reference/#vela_server_secret) provided to the worker.
 {{% /alert %}}
 
 ### VELA_SECRET_VAULT


### PR DESCRIPTION
Documentation for https://github.com/go-vela/server/pull/971

Will be merged when `v0.21.0` is released.