### PR TITLE
fix(services/mongo): make example work

### DIFF
--- a/content/usage/examples/mongo.md
+++ b/content/usage/examples/mongo.md
@@ -45,7 +45,7 @@ steps:
     commands:
       # sleeping can help ensure the service adequate time to start
 +      - sleep 15
-      - "mongo --host mongo --eval \"{ ping: 1 }\""
+      - /bin/mongosh --host mongo --eval 'db.runCommand("ping")'
 ```
 
 ### Detach
@@ -78,5 +78,5 @@ steps:
     commands:
       # sleeping can help ensure the service adequate time to start
 +      - sleep 15
-      - "mongo --host mongo --eval \"{ ping: 1 }\""
+      - /bin/mongosh --host mongo --eval 'db.runCommand("ping")'
 ```


### PR DESCRIPTION
happened to be using this as an example somewhere and noticed it doesn't work (anymore) as-is. biggest issue is that there is no `mongo` binary. this tweak makes it work.