### PR TITLE
fix: typo in scm/syncAll

### DIFF
--- a/content/reference/api/scm/syncAll.md
+++ b/content/reference/api/scm/syncAll.md
@@ -8,7 +8,7 @@ description: >
 ## Endpoint
 
 ```
-PATCH  /api/v1/scm/orgs/:org/sync
+GET  /api/v1/scm/orgs/:org/sync
 ```
 
 ## Parameters


### PR DESCRIPTION
Fix HTTP method typo