### PR TITLE
feat(schedules): update API response examples

### DIFF
--- a/content/reference/api/schedule/add.md
+++ b/content/reference/api/schedule/add.md
@@ -64,15 +64,68 @@ curl \
 
 ```json
 {
-  "id": 1,
-  "repo_id": 1,
-  "active": true,
-  "name": "hourly",
-  "entry": "0 * * * *",
-  "created_at": 1641314085,
-  "created_by": "octokitty",
-  "updated_at": 1641314085,
-  "updated_by": "octokitty",
-  "scheduled_at": 0
+	"id": 1,
+	"repo": {
+		"id": 1,
+		"owner": {
+			"id": 1,
+			"name": "octokitty",
+			"active": true
+		},
+		"org": "github",
+		"name": "octokitty",
+		"full_name": "github/octokitty",
+		"link": "https://github.com/github/octokitty",
+		"clone": "https://github.com/github/octokitty.git",
+		"branch": "main",
+		"topics": [],
+		"build_limit": 10,
+		"timeout": 30,
+		"counter": 0,
+		"visibility": "public",
+		"private": false,
+		"trusted": false,
+		"active": true,
+		"allow_events": {
+			"push": {
+				"branch": true,
+				"tag": false,
+				"delete_branch": false,
+				"delete_tag": false
+			},
+			"pull_request": {
+				"opened": false,
+				"edited": false,
+				"synchronize": false,
+				"reopened": false,
+				"labeled": false,
+				"unlabeled": false
+			},
+			"deployment": {
+				"created": false
+			},
+			"comment": {
+				"created": false,
+				"edited": false
+			},
+			"schedule": {
+				"run": false
+			}
+		},
+		"pipeline_type": "yaml",
+		"previous_name": "",
+		"approve_build": "fork-always"
+	},
+	"active": true,
+	"name": "hourly",
+	"entry": "0 * * * *",
+	"created_at": 1716495910,
+	"created_by": "octokitty",
+	"updated_at": 1716495910,
+	"updated_by": "octokitty",
+	"scheduled_at": 0,
+	"branch": "main",
+	"error": "",
+	"next_run": 1716499800
 }
 ```

--- a/content/reference/api/schedule/get.md
+++ b/content/reference/api/schedule/get.md
@@ -55,29 +55,135 @@ curl \
 
 ```json
 [
-  {
-    "id": 2,
-    "repo_id": 1,
-    "active": true,
-    "name": "nightly",
-    "entry": "0 0 * * *",
-    "created_at": 1641314086,
-    "created_by": "octokitty",
-    "updated_at": 1641314086,
-    "updated_by": "octokitty",
-    "scheduled_at": 0
-  },
-  {
-    "id": 1,
-    "repo_id": 1,
-    "active": true,
-    "name": "hourly",
-    "entry": "0 * * * *",
-    "created_at": 1641314085,
-    "created_by": "octokitty",
-    "updated_at": 1641314085,
-    "updated_by": "octokitty",
-    "scheduled_at": 0
-  }
+	{
+		"id": 1,
+		"repo": {
+			"id": 1,
+			"owner": {
+				"id": 1,
+				"name": "octokitty",
+				"active": true
+			},
+			"org": "github",
+			"name": "octokitty",
+			"full_name": "github/octokitty",
+			"link": "https://github.com/github/octokitty",
+			"clone": "https://github.com/github/octokitty.git",
+			"branch": "main",
+			"topics": [],
+			"build_limit": 10,
+			"timeout": 30,
+			"counter": 0,
+			"visibility": "public",
+			"private": false,
+			"trusted": false,
+			"active": true,
+			"allow_events": {
+				"push": {
+					"branch": true,
+					"tag": false,
+					"delete_branch": false,
+					"delete_tag": false
+				},
+				"pull_request": {
+					"opened": false,
+					"edited": false,
+					"synchronize": false,
+					"reopened": false,
+					"labeled": false,
+					"unlabeled": false
+				},
+				"deployment": {
+					"created": false
+				},
+				"comment": {
+					"created": false,
+					"edited": false
+				},
+				"schedule": {
+					"run": false
+				}
+			},
+			"pipeline_type": "yaml",
+			"previous_name": "",
+			"approve_build": "fork-always"
+		},
+		"active": true,
+		"name": "hourly",
+		"entry": "0 * * * *",
+		"created_at": 1716495910,
+		"created_by": "octokitty",
+		"updated_at": 1716495910,
+		"updated_by": "octokitty",
+		"scheduled_at": 0,
+		"branch": "main",
+		"error": "",
+		"next_run": 1716499800
+	},
+	{
+		"id": 2,
+		"repo": {
+			"id": 1,
+			"owner": {
+				"id": 1,
+				"name": "octokitty",
+				"active": true
+			},
+			"org": "github",
+			"name": "octokitty",
+			"full_name": "github/octokitty",
+			"link": "https://github.com/github/octokitty",
+			"clone": "https://github.com/github/octokitty.git",
+			"branch": "main",
+			"topics": [],
+			"build_limit": 10,
+			"timeout": 30,
+			"counter": 0,
+			"visibility": "public",
+			"private": false,
+			"trusted": false,
+			"active": true,
+			"allow_events": {
+				"push": {
+					"branch": true,
+					"tag": false,
+					"delete_branch": false,
+					"delete_tag": false
+				},
+				"pull_request": {
+					"opened": false,
+					"edited": false,
+					"synchronize": false,
+					"reopened": false,
+					"labeled": false,
+					"unlabeled": false
+				},
+				"deployment": {
+					"created": false
+				},
+				"comment": {
+					"created": false,
+					"edited": false
+				},
+				"schedule": {
+					"run": false
+				}
+			},
+			"pipeline_type": "yaml",
+			"previous_name": "",
+			"approve_build": "fork-always"
+		},
+		"active": true,
+		"name": "nightly",
+		"entry": "0 0 * * *",
+		"created_at": 1716495910,
+		"created_by": "octokitty",
+		"updated_at": 1716495910,
+		"updated_by": "octokitty",
+		"scheduled_at": 0,
+		"branch": "main",
+		"error": "",
+		"next_run": 1716499800
+	}
 ]
 ```

--- a/content/reference/api/schedule/remove.md
+++ b/content/reference/api/schedule/remove.md
@@ -52,5 +52,5 @@ curl \
 #### Response
 
 ```sh
-schedule "hourly" deleted
+"schedule hourly deleted"
 ```

--- a/content/reference/api/schedule/update.md
+++ b/content/reference/api/schedule/update.md
@@ -63,15 +63,68 @@ curl \
 
 ```json
 {
-  "id": 1,
-  "repo_id": 1,
-  "active": false,
-  "name": "hourly",
-  "entry": "0 * * * *",
-  "created_at": 1641314085,
-  "created_by": "octokitty",
-  "updated_at": 1641314086,
-  "updated_by": "octokitty",
-  "scheduled_at": 0
+	"id": 1,
+	"repo": {
+		"id": 1,
+		"owner": {
+			"id": 1,
+			"name": "octokitty",
+			"active": true
+		},
+		"org": "github",
+		"name": "octokitty",
+		"full_name": "github/octokitty",
+		"link": "https://github.com/github/octokitty",
+		"clone": "https://github.com/github/octokitty.git",
+		"branch": "main",
+		"topics": [],
+		"build_limit": 10,
+		"timeout": 30,
+		"counter": 0,
+		"visibility": "public",
+		"private": false,
+		"trusted": false,
+		"active": true,
+		"allow_events": {
+			"push": {
+				"branch": true,
+				"tag": false,
+				"delete_branch": false,
+				"delete_tag": false
+			},
+			"pull_request": {
+				"opened": false,
+				"edited": false,
+				"synchronize": false,
+				"reopened": false,
+				"labeled": false,
+				"unlabeled": false
+			},
+			"deployment": {
+				"created": false
+			},
+			"comment": {
+				"created": false,
+				"edited": false
+			},
+			"schedule": {
+				"run": false
+			}
+		},
+		"pipeline_type": "yaml",
+		"previous_name": "",
+		"approve_build": "fork-always"
+	},
+	"active": false,
+	"name": "hourly",
+	"entry": "0 * * * *",
+	"created_at": 1716495910,
+	"created_by": "octokitty",
+	"updated_at": 1716495910,
+	"updated_by": "octokitty",
+	"scheduled_at": 0,
+	"branch": "main",
+	"error": "",
+	"next_run": 1716499800
 }
 ```

--- a/content/reference/api/schedule/view.md
+++ b/content/reference/api/schedule/view.md
@@ -55,15 +55,68 @@ curl \
 
 ```json
 {
-  "id": 1,
-  "repo_id": 1,
-  "active": true,
-  "name": "hourly",
-  "entry": "0 * * * *",
-  "created_at": 1641314085,
-  "created_by": "octokitty",
-  "updated_at": 1641314085,
-  "updated_by": "octokitty",
-  "scheduled_at": 0
+	"id": 1,
+	"repo": {
+		"id": 1,
+		"owner": {
+			"id": 1,
+			"name": "octokitty",
+			"active": true
+		},
+		"org": "github",
+		"name": "octokitty",
+		"full_name": "github/octokitty",
+		"link": "https://github.com/github/octokitty",
+		"clone": "https://github.com/github/octokitty.git",
+		"branch": "main",
+		"topics": [],
+		"build_limit": 10,
+		"timeout": 30,
+		"counter": 0,
+		"visibility": "public",
+		"private": false,
+		"trusted": false,
+		"active": true,
+		"allow_events": {
+			"push": {
+				"branch": true,
+				"tag": false,
+				"delete_branch": false,
+				"delete_tag": false
+			},
+			"pull_request": {
+				"opened": false,
+				"edited": false,
+				"synchronize": false,
+				"reopened": false,
+				"labeled": false,
+				"unlabeled": false
+			},
+			"deployment": {
+				"created": false
+			},
+			"comment": {
+				"created": false,
+				"edited": false
+			},
+			"schedule": {
+				"run": false
+			}
+		},
+		"pipeline_type": "yaml",
+		"previous_name": "",
+		"approve_build": "fork-always"
+	},
+	"active": true,
+	"name": "hourly",
+	"entry": "0 * * * *",
+	"created_at": 1716495910,
+	"created_by": "octokitty",
+	"updated_at": 1716495910,
+	"updated_by": "octokitty",
+	"scheduled_at": 0,
+	"branch": "main",
+	"error": "",
+	"next_run": 1716499800
 }
 ```

--- a/content/reference/cli/schedule/add.md
+++ b/content/reference/cli/schedule/add.md
@@ -59,22 +59,75 @@ $ vela add schedule --schedule hourly --entry '0 * * * *'
 #### Targeted Request
 
 ```sh
-$ vela add schedule --org github --repo octocat --schedule hourly --entry '0 * * * *'
+$ vela add schedule --org github --repo octocat --schedule hourly --entry '0 * * * *' --output json
 ```
 
 #### Response
 ```sh
 {
-  Active: true,
-  CreatedAt: 1641314085,
-  CreatedBy: octokitty,
-  Entry: 0 * * * *,
-  ID: 1,
-  Name: hourly,
-  RepoID: 1,
-  ScheduledAt: 0,
-  UpdatedAt: 1641314085,
-  UpdatedBy: octokitty,
+	"id": 1,
+	"repo": {
+		"id": 1,
+		"owner": {
+			"id": 1,
+			"name": "octokitty",
+			"active": true
+		},
+		"org": "github",
+		"name": "octokitty",
+		"full_name": "github/octokitty",
+		"link": "https://github.com/github/octokitty",
+		"clone": "https://github.com/github/octokitty.git",
+		"branch": "main",
+		"topics": [],
+		"build_limit": 10,
+		"timeout": 30,
+		"counter": 0,
+		"visibility": "public",
+		"private": false,
+		"trusted": false,
+		"active": true,
+		"allow_events": {
+			"push": {
+				"branch": true,
+				"tag": false,
+				"delete_branch": false,
+				"delete_tag": false
+			},
+			"pull_request": {
+				"opened": false,
+				"edited": false,
+				"synchronize": false,
+				"reopened": false,
+				"labeled": false,
+				"unlabeled": false
+			},
+			"deployment": {
+				"created": false
+			},
+			"comment": {
+				"created": false,
+				"edited": false
+			},
+			"schedule": {
+				"run": false
+			}
+		},
+		"pipeline_type": "yaml",
+		"previous_name": "",
+		"approve_build": "fork-always"
+	},
+	"active": true,
+	"name": "hourly",
+	"entry": "0 * * * *",
+	"created_at": 1716495910,
+	"created_by": "octokitty",
+	"updated_at": 1716495910,
+	"updated_by": "octokitty",
+	"scheduled_at": 0,
+	"branch": "main",
+	"error": "",
+	"next_run": 1716499800
 }
 ```
 

--- a/content/reference/cli/schedule/get.md
+++ b/content/reference/cli/schedule/get.md
@@ -63,9 +63,9 @@ $ vela get schedule --org github --repo octocat
 
 #### Response
 ```sh
-NAME   	ENTRY    	ACTIVE	SCHEDULED_AT
-nightly	0 0 * * *	true  	a second ago
-hourly 	0 * * * *	true  	a second ago
+NAME   	ENTRY    	ACTIVE	SCHEDULED_AT    	BRANCH
+nightly	0 0 * * *	true  	a long while ago	main  
+hourly 	0 * * * *	true  	a long while ago	main  
 ```
 
 ## Examples

--- a/content/reference/cli/schedule/remove.md
+++ b/content/reference/cli/schedule/remove.md
@@ -69,7 +69,7 @@ $ vela remove schedule --org github --repo octocat --schedule hourly
 #### Response
 
 ```sh
-schedule "hourly" was deleted
+schedule hourly deleted
 ```
 
 ## Examples

--- a/content/reference/cli/schedule/update.md
+++ b/content/reference/cli/schedule/update.md
@@ -63,23 +63,76 @@ $ vela update schedule --name hourly --active false
 #### Targeted Request
 
 ```sh
-$ vela update schedule --org github --repo octocat --name hourly --active false
+$ vela update schedule --org github --repo octocat --name hourly --active false --output json
 ```
 
 #### Response
 
 ```sh
 {
-  Active: false,
-  CreatedAt: 1641314085,
-  CreatedBy: octokitty,
-  Entry: 0 * * * *,
-  ID: 1,
-  Name: hourly,
-  RepoID: 1,
-  ScheduledAt: 0,
-  UpdatedAt: 1641314086,
-  UpdatedBy: octokitty,
+	"id": 1,
+	"repo": {
+		"id": 1,
+		"owner": {
+			"id": 1,
+			"name": "octokitty",
+			"active": true
+		},
+		"org": "github",
+		"name": "octokitty",
+		"full_name": "github/octokitty",
+		"link": "https://github.com/github/octokitty",
+		"clone": "https://github.com/github/octokitty.git",
+		"branch": "main",
+		"topics": [],
+		"build_limit": 10,
+		"timeout": 30,
+		"counter": 0,
+		"visibility": "public",
+		"private": false,
+		"trusted": false,
+		"active": true,
+		"allow_events": {
+			"push": {
+				"branch": true,
+				"tag": false,
+				"delete_branch": false,
+				"delete_tag": false
+			},
+			"pull_request": {
+				"opened": false,
+				"edited": false,
+				"synchronize": false,
+				"reopened": false,
+				"labeled": false,
+				"unlabeled": false
+			},
+			"deployment": {
+				"created": false
+			},
+			"comment": {
+				"created": false,
+				"edited": false
+			},
+			"schedule": {
+				"run": false
+			}
+		},
+		"pipeline_type": "yaml",
+		"previous_name": "",
+		"approve_build": "fork-always"
+	},
+	"active": false,
+	"name": "hourly",
+	"entry": "0 * * * *",
+	"created_at": 1716495910,
+	"created_by": "octokitty",
+	"updated_at": 1716495910,
+	"updated_by": "octokitty",
+	"scheduled_at": 0,
+	"branch": "main",
+	"error": "",
+	"next_run": 1716499800
 }
 ```
 

--- a/content/reference/cli/schedule/view.md
+++ b/content/reference/cli/schedule/view.md
@@ -57,22 +57,75 @@ $ vela view schedule --schedule hourly
 #### Targeted Request
 
 ```sh
-$ vela view schedule --org github --repo octocat --schedule hourly
+$ vela view schedule --org github --repo octocat --schedule hourly --output json
 ```
 
 #### Response
 ```sh
 {
-  Active: true,
-  CreatedAt: 1641314085,
-  CreatedBy: octokitty,
-  Entry: 0 * * * *,
-  ID: 1,
-  Name: hourly,
-  RepoID: 1,
-  ScheduledAt: 0,
-  UpdatedAt: 1641314085,
-  UpdatedBy: octokitty,
+	"id": 1,
+	"repo": {
+		"id": 1,
+		"owner": {
+			"id": 1,
+			"name": "octokitty",
+			"active": true
+		},
+		"org": "github",
+		"name": "octokitty",
+		"full_name": "github/octokitty",
+		"link": "https://github.com/github/octokitty",
+		"clone": "https://github.com/github/octokitty.git",
+		"branch": "main",
+		"topics": [],
+		"build_limit": 10,
+		"timeout": 30,
+		"counter": 0,
+		"visibility": "public",
+		"private": false,
+		"trusted": false,
+		"active": true,
+		"allow_events": {
+			"push": {
+				"branch": true,
+				"tag": false,
+				"delete_branch": false,
+				"delete_tag": false
+			},
+			"pull_request": {
+				"opened": false,
+				"edited": false,
+				"synchronize": false,
+				"reopened": false,
+				"labeled": false,
+				"unlabeled": false
+			},
+			"deployment": {
+				"created": false
+			},
+			"comment": {
+				"created": false,
+				"edited": false
+			},
+			"schedule": {
+				"run": false
+			}
+		},
+		"pipeline_type": "yaml",
+		"previous_name": "",
+		"approve_build": "fork-always"
+	},
+	"active": true,
+	"name": "hourly",
+	"entry": "0 * * * *",
+	"created_at": 1716495910,
+	"created_by": "octokitty",
+	"updated_at": 1716495910,
+	"updated_by": "octokitty",
+	"scheduled_at": 0,
+	"branch": "main",
+	"error": "",
+	"next_run": 1716499800
 }
 ```
 


### PR DESCRIPTION
## Description
Updated documented API response examples for Schedules to reflect the following changes:
1. Turning `Schedule` into a nested object by populating `repo` field 
2. Addition of `error` field to `Schedule` object
3. Addition of `next_run` field to Schedule API responses

## Related
https://github.com/go-vela/community/issues/872
https://github.com/go-vela/community/issues/871