### PR TITLE
fix(docs): use proper syntax for query parameter

### DIFF
--- a/content/usage/open_id_connect.md
+++ b/content/usage/open_id_connect.md
@@ -49,7 +49,7 @@ steps:
       commands:
         - >
             AUTH_TOKEN=$(curl -H "Authorization: Bearer $VELA_ID_TOKEN_REQUEST_TOKEN"
-            "$VELA_ID_TOKEN_REQUEST_URL&audience=artifactory" |
+            "$VELA_ID_TOKEN_REQUEST_URL?audience=artifactory" |
             jq -r '.value')
         - >
             REQ=$(curl -s -X POST -H "Token: $AUTH_TOKEN"


### PR DESCRIPTION
The current example results in a `404 page not found` response since the first query parameter needs to be `?` instead of `&`.