### PR TITLE
docs(registry): add vela-aws-credentials

### DIFF
--- a/content/plugins/registry/pipeline/aws-credentials.md
+++ b/content/plugins/registry/pipeline/aws-credentials.md
@@ -1,0 +1,5 @@
+---
+title: "AWS Credentials"
+---
+
+{{% plugin-docs "Cargill/vela-aws-credentials" "DOCS.md" %}}


### PR DESCRIPTION
Adding the newly open-sourced [vela-aws-credentials plugin](https://github.com/Cargill/vela-aws-credentials) which allows for obtaining temporary AWS credentials via the recently added OIDC integration. This plugin also includes several public Go functions for interacting with Vela and AWS, which other plugins might choose to use in the future.